### PR TITLE
focus-ring support across sp-* widgets + bug fixes + enhancements

### DIFF
--- a/packages/action-button/src/uxp-action-button.css
+++ b/packages/action-button/src/uxp-action-button.css
@@ -86,3 +86,11 @@ governing permissions and limitations under the License.
             )
     );
 }
+
+/* workaround for missing logical property 'inset', fixed layouting of focus-ring */
+:host:after {
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+}

--- a/packages/asset/src/uxp-asset.css
+++ b/packages/asset/src/uxp-asset.css
@@ -11,3 +11,9 @@ governing permissions and limitations under the License.
 */
 
 /* write uxp style overrides */
+
+/* workaround for missing logical property 'max-block-size' & 'max-inline-size' */
+::slotted(*) {
+    max-height: 100%;
+    max-width: 100%;
+}

--- a/packages/button/src/uxp-button.css
+++ b/packages/button/src/uxp-button.css
@@ -56,3 +56,11 @@ governing permissions and limitations under the License.
         var(--spectrum-button-padding-label-to-icon)
     );
 }
+
+/* workaround for missing logical property 'inset', fixed layouting of focus-ring */
+:host:after {
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+}

--- a/packages/button/src/uxp-clear-button.css
+++ b/packages/button/src/uxp-clear-button.css
@@ -11,3 +11,11 @@ governing permissions and limitations under the License.
 */
 
 /* write uxp style overrides */
+
+/* workaround for missing logical property 'inset', fixed layouting of focus-ring */
+:host:after {
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+}

--- a/packages/card/src/uxp-card.css
+++ b/packages/card/src/uxp-card.css
@@ -64,18 +64,9 @@ governing permissions and limitations under the License.
     top: 0px;
     left: 0px;
     right: 0px;
-    margin-top: calc(
-        var(
-                --mod-card-focus-indicator-width,
-                var(--spectrum-card-focus-indicator-width)
-            ) * -1
-    );
-    margin-left: calc(
-        var(
-                --mod-card-focus-indicator-width,
-                var(--spectrum-card-focus-indicator-width)
-            ) * -1
-    );
+    /* Workaround to handle missing box-sizing support in UXP, fixed focus-ring layout for sp-card */
+    margin-top: 0px;
+    margin-left: 0px;
 }
 
 #cover-photo {
@@ -154,4 +145,126 @@ governing permissions and limitations under the License.
 
 ::slotted(*) {
     height: 100%;
+}
+
+:host([variant='gallery']) #preview:after,
+:host([variant='quiet']) #preview:after {
+    height: 100%;
+    width: 100%;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin-top: calc(
+        var(
+                --mod-card-focus-indicator-width,
+                var(--spectrum-card-focus-indicator-width)
+            ) * -1
+    );
+    margin-left: calc(
+        var(
+                --mod-card-focus-indicator-width,
+                var(--spectrum-card-focus-indicator-width)
+            ) * -1
+    );
+}
+
+:host([variant='gallery']),
+:host([variant='quiet']) {
+    height: 100%;
+    min-width: var(
+        --mod-card-minimum-width,
+        var(--spectrum-card-minimum-width)
+    );
+}
+
+#preview {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: var(
+        --mod-card-corner-radius,
+        var(--spectrum-card-corner-radius)
+    );
+    border-top-left-radius: var(
+        --mod-card-corner-radius,
+        var(--spectrum-card-corner-radius)
+    );
+}
+
+.subtitle + ::slotted([slot='description']):before {
+    padding-right: var(
+        --mod-card-subtitle-padding-right,
+        var(--spectrum-card-subtitle-padding-right)
+    );
+}
+
+:host([variant='gallery']) #preview,
+:host([variant='quiet']) #preview {
+    width: 100%;
+    min-height: var(
+        --mod-card-preview-minimum-height,
+        var(--spectrum-card-preview-minimum-height)
+    );
+}
+
+:host([variant='gallery']) #preview:before,
+:host([variant='quiet']) #preview:before {
+    height: 100%;
+    width: 100%;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+}
+
+:host([horizontal]) #preview {
+    border-top-left-radius: calc(
+        var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) -
+            var(--mod-card-border-width, var(--spectrum-card-border-width))
+    );
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+    border-bottom-left-radius: calc(
+        var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) -
+            var(--mod-card-border-width, var(--spectrum-card-border-width))
+    );
+    min-height: 0px;
+}
+
+:host([horizontal]) .body {
+    padding-top: 0px;
+    padding-bottom: 0px;
+    padding-left: var(
+        --mod-card-horizontal-body-padding,
+        var(--spectrum-card-horizontal-body-padding)
+    );
+    padding-right: var(
+        --mod-card-horizontal-body-padding,
+        var(--spectrum-card-horizontal-body-padding)
+    );
+}
+
+:host([horizontal]) .header,
+:host([horizontal]) .content {
+    height: auto;
+    margin-top: 0px;
+}
+
+:host([horizontal]) .title {
+    padding-right: 0px;
+}
+
+:host([horizontal]) .content {
+    margin-bottom: 0px;
+}
+
+#cover-photo ::slotted(*) {
+    border-top-right-radius: calc(
+        var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) -
+            var(--mod-card-border-width, var(--spectrum-card-border-width))
+    );
+    border-top-left-radius: calc(
+        var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) -
+            var(--mod-card-border-width, var(--spectrum-card-border-width))
+    );
 }

--- a/packages/checkbox/src/uxp-checkbox.css
+++ b/packages/checkbox/src/uxp-checkbox.css
@@ -49,3 +49,11 @@ governing permissions and limitations under the License.
         var(--spectrum-checkbox-control-size)
     );
 }
+
+/* workaround for missing logical property 'inset', fixed layouting of focus-ring */
+#box:after {
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+}

--- a/packages/radio/src/uxp-radio.css
+++ b/packages/radio/src/uxp-radio.css
@@ -45,3 +45,18 @@ governing permissions and limitations under the License.
         var(--spectrum-radio-text-to-control)
     );
 }
+
+/* workaround for missing 'box-sizing' support, fixed layouting of focus-ring by adding twice of var(--spectrum-radio-focus-indicator-thickness) to the height & width respectively */
+#input.focus-visible + #button:after,
+:host(.focus-visible) #input + #button:after {
+    height: calc(
+        var(--spectrum-radio-button-control-size) +
+            var(--spectrum-radio-focus-indicator-gap) * 2 +
+            var(--spectrum-radio-focus-indicator-thickness) * 2
+    );
+    width: calc(
+        var(--spectrum-radio-button-control-size) +
+            var(--spectrum-radio-focus-indicator-gap) * 2 +
+            var(--spectrum-radio-focus-indicator-thickness) * 2
+    );
+}

--- a/packages/switch/src/uxp-switch.css
+++ b/packages/switch/src/uxp-switch.css
@@ -66,6 +66,13 @@ governing permissions and limitations under the License.
     bottom: 0;
     left: 0;
     right: 0;
+    /* Fixed focus-ring layouting aorund sp-switch */
+    border-radius: calc(
+        var(--mod-switch-control-height, var(--spectrum-switch-control-height)) /
+            2 +
+            var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) *
+            2
+    );
 }
 
 #switch:before {

--- a/packages/textfield/src/uxp-textfield.css
+++ b/packages/textfield/src/uxp-textfield.css
@@ -256,3 +256,22 @@ governing permissions and limitations under the License.
         var(--spectrum-text-area-min-inline-size)
     );
 }
+
+/* Workaround for missing 'min-block-size' logical property  */
+:host([multiline][quiet]) .input {
+    min-height: var(
+        --mod-text-area-min-block-size-quiet,
+        var(--spectrum-text-area-min-block-size-quiet)
+    );
+}
+
+/* Workaround to fix focus-ring layouting in quiet variant, replacing relevant logical properties with trivial ones */
+:host([quiet]) #textfield:after {
+    height: var(
+        --mod-textfield-focus-indicator-width,
+        var(--spectrum-textfield-focus-indicator-width)
+    );
+    width: 100%;
+    left: 0;
+    right: 0;
+}

--- a/projects/swc-starter-webpack/src/example_usages/sp-action-button.html
+++ b/projects/swc-starter-webpack/src/example_usages/sp-action-button.html
@@ -15,55 +15,560 @@ governing permissions and limitations under the License.
 <div id="content">
     <div id="left">
         <div id="subtitle">sp-action-button</div>
-        <div>
-            <sp-action-button>Spectrum Action Button</sp-action-button>
-            <sp-action-button disabled>Spectrum Action Button</sp-action-button>
+
+        <div id="variantLabel">sizes</div>
+        <div class="demo-example">
+            <sp-field-label for="xs">Extra Small</sp-field-label>
+            <sp-action-group size="xs">
+                <sp-action-button>Edit</sp-action-button>
+                <sp-action-button>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                    Edit
+                </sp-action-button>
+                <sp-action-button>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                </sp-action-button>
+                <sp-action-button hold-affordance>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                </sp-action-button>
+            </sp-action-group>
+        </div>
+        <div class="demo-example">
+            <sp-field-label for="s">Small</sp-field-label>
+            <sp-action-group size="s">
+                <sp-action-button>Edit</sp-action-button>
+                <sp-action-button>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                    Edit
+                </sp-action-button>
+                <sp-action-button>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                </sp-action-button>
+                <sp-action-button hold-affordance>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                </sp-action-button>
+            </sp-action-group>
+        </div>
+        <div class="demo-example">
+            <sp-field-label for="m">Medium</sp-field-label>
+            <sp-action-group size="m">
+                <sp-action-button>Edit</sp-action-button>
+                <sp-action-button>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                    Edit
+                </sp-action-button>
+                <sp-action-button>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                </sp-action-button>
+                <sp-action-button hold-affordance>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                </sp-action-button>
+            </sp-action-group>
+        </div>
+        <div class="demo-example">
+            <sp-field-label for="l">Large</sp-field-label>
+            <sp-action-group size="l">
+                <sp-action-button>Edit</sp-action-button>
+                <sp-action-button>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                    Edit
+                </sp-action-button>
+                <sp-action-button>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                </sp-action-button>
+                <sp-action-button hold-affordance>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                </sp-action-button>
+            </sp-action-group>
+        </div>
+        <div class="demo-example">
+            <sp-field-label for="xl">Extra Large</sp-field-label>
+            <sp-action-group size="xl">
+                <sp-action-button>Edit</sp-action-button>
+                <sp-action-button>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                    Edit
+                </sp-action-button>
+                <sp-action-button>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                </sp-action-button>
+                <sp-action-button hold-affordance>
+                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                </sp-action-button>
+            </sp-action-group>
         </div>
 
-        <div>
-            <sp-action-button quiet>Quiet Action Button</sp-action-button>
-            <sp-action-button quiet>
-                <sp-icon-edit slot="icon"></sp-icon-edit>
-                Quiet Action Button
-            </sp-action-button>
-            <sp-action-button quiet>
-                <sp-icon-edit slot="icon"></sp-icon-edit>
-            </sp-action-button>
-            <sp-action-button quiet hold-affordance>
-                <sp-icon-edit slot="icon"></sp-icon-edit>
-            </sp-action-button>
+        <div id="variantLabel">standard variant</div>
+        <div class="demo-example" style="display: flex">
+            <div>
+                <div>
+                    <sp-field-label for="standard">Default</sp-field-label>
+                    <sp-action-group id="standard">
+                        <sp-action-button>Edit</sp-action-button>
+                        <sp-action-button>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button hold-affordance>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-selected">
+                        Selected
+                    </sp-field-label>
+                    <sp-action-group id="standard-selected">
+                        <sp-action-button selected>Edit</sp-action-button>
+                        <sp-action-button selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button selected hold-affordance>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-disabled">
+                        Disabled
+                    </sp-field-label>
+                    <sp-action-group id="standard-disabled">
+                        <sp-action-button disabled>Edit</sp-action-button>
+                        <sp-action-button disabled>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button disabled>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button disabled hold-affordance>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-disabled-selected">
+                        Disabled + Selected
+                    </sp-field-label>
+                    <sp-action-group id="standard-disabled-selected">
+                        <sp-action-button disabled selected>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button disabled selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button disabled selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button disabled selected hold-affordance>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+            </div>
         </div>
 
-        <div>
-            <sp-action-button emphasized>
-                Emphasized Action Button
-            </sp-action-button>
-            <sp-action-button emphasized>
-                <sp-icon-edit slot="icon"></sp-icon-edit>
-                Emphasized Action Button
-            </sp-action-button>
-            <sp-action-button emphasized>
-                <sp-icon-edit slot="icon"></sp-icon-edit>
-            </sp-action-button>
-            <sp-action-button emphasized hold-affordance>
-                <sp-icon-edit slot="icon"></sp-icon-edit>
-            </sp-action-button>
+        <div id="variantLabel">quiet variant</div>
+        <div class="demo-example" style="display: flex">
+            <div>
+                <div>
+                    <sp-field-label for="standard">Default</sp-field-label>
+                    <sp-action-group quiet id="standard">
+                        <sp-action-button quiet>Edit</sp-action-button>
+                        <sp-action-button quiet>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button quiet>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button quiet hold-affordance>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-selected">
+                        Selected
+                    </sp-field-label>
+                    <sp-action-group quiet id="standard-selected">
+                        <sp-action-button quiet selected>Edit</sp-action-button>
+                        <sp-action-button quiet selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button quiet selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button quiet selected hold-affordance>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-disabled">
+                        Disabled
+                    </sp-field-label>
+                    <sp-action-group quiet id="standard-disabled">
+                        <sp-action-button quiet disabled>Edit</sp-action-button>
+                        <sp-action-button quiet disabled>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button quiet disabled>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button quiet disabled hold-affordance>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-disabled-selected">
+                        Disabled + Selected
+                    </sp-field-label>
+                    <sp-action-group quiet id="standard-disabled-selected">
+                        <sp-action-button quiet disabled selected>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button quiet disabled selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button quiet disabled selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button
+                            quiet
+                            disabled
+                            selected
+                            hold-affordance
+                        >
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+            </div>
         </div>
 
-        <div>
-            <sp-action-button emphasized quiet selected>
-                Emphasized Quiet selected
-            </sp-action-button>
-            <sp-action-button emphasized quiet selected>
-                <sp-icon-edit slot="icon"></sp-icon-edit>
-                Emphasized Quiet selected
-            </sp-action-button>
-            <sp-action-button emphasized quiet selected>
-                <sp-icon-edit slot="icon"></sp-icon-edit>
-            </sp-action-button>
-            <sp-action-button emphasized quiet selected hold-affordance>
-                <sp-icon-edit slot="icon"></sp-icon-edit>
-            </sp-action-button>
+        <div id="variantLabel">emphasized variant</div>
+        <div class="demo-example" style="display: flex">
+            <div>
+                <div>
+                    <sp-field-label for="standard">Default</sp-field-label>
+                    <sp-action-group emphasized id="standard">
+                        <sp-action-button emphasized>Edit</sp-action-button>
+                        <sp-action-button emphasized>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button emphasized hold-affordance>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-selected">
+                        Selected
+                    </sp-field-label>
+                    <sp-action-group emphasized id="standard-selected">
+                        <sp-action-button emphasized selected>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button emphasized selected hold-affordance>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-disabled">
+                        Disabled
+                    </sp-field-label>
+                    <sp-action-group emphasized id="standard-disabled">
+                        <sp-action-button emphasized disabled>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized disabled>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized disabled>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button emphasized disabled hold-affordance>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-disabled-selected">
+                        Disabled + Selected
+                    </sp-field-label>
+                    <sp-action-group emphasized id="standard-disabled-selected">
+                        <sp-action-button emphasized disabled selected>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized disabled selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized disabled selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button
+                            emphasized
+                            disabled
+                            selected
+                            hold-affordance
+                        >
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+            </div>
+        </div>
+
+        <div id="variantLabel">emphasized + quiet variant</div>
+        <div class="demo-example" style="display: flex">
+            <div>
+                <div>
+                    <sp-field-label for="standard">Default</sp-field-label>
+                    <sp-action-group emphasized quiet id="standard">
+                        <sp-action-button emphasized quiet>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized quiet>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized quiet>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button emphasized quiet hold-affordance>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-selected">
+                        Selected
+                    </sp-field-label>
+                    <sp-action-group emphasized quiet id="standard-selected">
+                        <sp-action-button emphasized quiet selected>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized quiet selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized quiet selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button
+                            emphasized
+                            quiet
+                            selected
+                            hold-affordance
+                        >
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-disabled">
+                        Disabled
+                    </sp-field-label>
+                    <sp-action-group emphasized quiet id="standard-disabled">
+                        <sp-action-button emphasized quiet disabled>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized quiet disabled>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized quiet disabled>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button
+                            emphasized
+                            quiet
+                            disabled
+                            hold-affordance
+                        >
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+
+                <div>
+                    <sp-field-label for="standard-disabled-selected">
+                        Disabled + Selected
+                    </sp-field-label>
+                    <sp-action-group
+                        emphasized
+                        quiet
+                        id="standard-disabled-selected"
+                    >
+                        <sp-action-button emphasized quiet disabled selected>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized quiet disabled selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                            Edit
+                        </sp-action-button>
+                        <sp-action-button emphasized quiet disabled selected>
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                        <sp-action-button
+                            emphasized
+                            quiet
+                            disabled
+                            selected
+                            hold-affordance
+                        >
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-action-button>
+                    </sp-action-group>
+                </div>
+            </div>
+        </div>
+
+        <div id="variantLabel">hold-affordance</div>
+        <div class="demo-example" style="display: flex">
+            <div>
+                <overlay-trigger placement="bottom-start">
+                    <sp-action-button
+                        label="Edit"
+                        hold-affordance
+                        slot="trigger"
+                    >
+                        <sp-icon-edit slot="icon"></sp-icon-edit>
+                    </sp-action-button>
+                    <sp-popover slot="longpress-content" dialog tip>
+                        <p
+                            style="
+                                color: var(
+                                    --spectrum-neutral-content-color-default
+                                );
+                            "
+                        >
+                            This content is triggered by the "longpress"
+                            interaction.
+                        </p>
+                    </sp-popover>
+                </overlay-trigger>
+
+                <overlay-trigger placement="top">
+                    <sp-action-button hold-affordance quiet slot="trigger">
+                        Show Longpress Content
+                    </sp-action-button>
+                    <sp-popover slot="longpress-content" dialog tip>
+                        <p
+                            style="
+                                color: var(
+                                    --spectrum-neutral-content-color-default
+                                );
+                            "
+                        >
+                            This content is triggered by the "longpress"
+                            interaction.
+                        </p>
+                    </sp-popover>
+                </overlay-trigger>
+
+                <overlay-trigger placement="top-end">
+                    <sp-action-button hold-affordance selected slot="trigger">
+                        <sp-icon-edit slot="icon"></sp-icon-edit>
+                        Extended Content with Longpress
+                    </sp-action-button>
+                    <sp-popover slot="longpress-content" dialog tip>
+                        <p
+                            style="
+                                color: var(
+                                    --spectrum-neutral-content-color-default
+                                );
+                            "
+                        >
+                            This content is triggered by the "longpress"
+                            interaction.
+                        </p>
+                    </sp-popover>
+                </overlay-trigger>
+            </div>
+        </div>
+
+        <div id="variantLabel">hold-affordance</div>
+        <div class="demo-example" style="display: flex">
+            <div>
+                <div>
+                    <sp-field-label for="toggles-default">
+                        Standard
+                    </sp-field-label>
+                    <sp-action-button toggles id="toggles-default">
+                        Toggle button
+                    </sp-action-button>
+                </div>
+                <div>
+                    <sp-field-label for="toggles-quiet">Quiet</sp-field-label>
+                    <sp-action-button toggles quiet id="toggles-quiet">
+                        Toggle button
+                    </sp-action-button>
+                </div>
+                <div>
+                    <sp-field-label for="toggles-emphasized">
+                        Emphasized
+                    </sp-field-label>
+                    <sp-action-button
+                        toggles
+                        emphasized
+                        id="toggles-emphasized"
+                    >
+                        Toggle button
+                    </sp-action-button>
+                </div>
+                <div>
+                    <sp-field-label for="toggles-emphasized-quiet">
+                        Emphasized + Quiet
+                    </sp-field-label>
+                    <sp-action-button
+                        toggles
+                        emphasized
+                        quiet
+                        id="toggles-emphasized-quiet"
+                    >
+                        Toggle button
+                    </sp-action-button>
+                </div>
+            </div>
         </div>
     </div>
     <div id="right">

--- a/projects/swc-starter-webpack/src/example_usages/sp-button.html
+++ b/projects/swc-starter-webpack/src/example_usages/sp-button.html
@@ -15,53 +15,216 @@ governing permissions and limitations under the License.
 <div id="content">
     <div id="left">
         <div id="subtitle">sp-button</div>
-        <div>
-            <sp-button
-                treatment="fill"
-                variant="primary"
-                style="margin: 10px; margin-left: 0px"
-            >
-                Primary, Fill
-            </sp-button>
-            <sp-button
-                treatment="fill"
-                variant="secondary"
-                style="margin: 10px"
-            >
-                Secondary, Fill
-            </sp-button>
-            <sp-button treatment="fill" variant="negative" style="margin: 10px">
-                Negative, Fill
-            </sp-button>
+
+        <div id="variantLabel">sizes</div>
+        <div class="demo-example" style="display: flex">
+            <div class="size-div" style="display: block">
+                <sp-field-label for="s">Small</sp-field-label>
+                <sp-button size="s">Small</sp-button>
+            </div>
+
+            <div class="size-div" style="display: block; margin-left: 10px">
+                <sp-field-label for="m">Medium</sp-field-label>
+                <sp-button size="m">Medium</sp-button>
+            </div>
+
+            <div class="size-div" style="display: block; margin-left: 10px">
+                <sp-field-label for="L">Large</sp-field-label>
+                <sp-button size="l">Large</sp-button>
+            </div>
+
+            <div class="size-div" style="display: block; margin-left: 10px">
+                <sp-field-label for="XL">Extra large</sp-field-label>
+                <sp-button size="xl">Extra large</sp-button>
+            </div>
         </div>
-        <div>
-            <sp-button variant="primary" style="margin: 10px; margin-left: 0px">
-                <svg
-                    slot="icon"
-                    viewBox="0 0 36 36"
-                    focusable="false"
-                    aria-hidden="true"
-                    role="img"
+
+        <div id="variantLabel">content</div>
+        <div class="demo-example" style="display: flex">
+            <sp-button-group>
+                <sp-button variant="primary">Label only</sp-button>
+                <sp-button variant="primary">
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                    Icon + Label
+                </sp-button>
+                <sp-button variant="primary">
+                    <svg
+                        slot="icon"
+                        viewBox="0 0 36 36"
+                        focusable="false"
+                        aria-hidden="true"
+                        role="img"
+                    >
+                        <path
+                            d="M16 36a4.407 4.407 0 0 0 4-4h-8a4.407 4.407 0 0 0 4 4zm9.143-24.615c0-3.437-3.206-4.891-7.143-5.268V3a1.079 1.079 0 0 0-1.143-1h-1.714A1.079 1.079 0 0 0 14 3v3.117c-3.937.377-7.143 1.831-7.143 5.268C6.857 26.8 2 26.111 2 28.154V30h28v-1.846C30 26 25.143 26.8 25.143 11.385z"
+                        ></path>
+                    </svg>
+                    SVG Icon + Label
+                </sp-button>
+                <sp-button variant="primary" label="Icon only" icon-only>
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                </sp-button>
+            </sp-button-group>
+        </div>
+
+        <div id="variantLabel">variants</div>
+        <div class="demo-example" style="display: flex">
+            <sp-button-group style="min-width: max-content">
+                <sp-button variant="accent">Label only</sp-button>
+                <sp-button variant="accent">
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                    Icon + Label
+                </sp-button>
+                <sp-button variant="accent" label="Icon only" icon-only>
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                </sp-button>
+            </sp-button-group>
+        </div>
+
+        <div class="demo-example" style="display: flex">
+            <sp-button-group style="min-width: max-content">
+                <sp-button variant="primary">Label only</sp-button>
+                <sp-button variant="primary">
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                    Icon + Label
+                </sp-button>
+                <sp-button variant="primary" label="Icon only" icon-only>
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                </sp-button>
+            </sp-button-group>
+        </div>
+
+        <div class="demo-example" style="display: flex">
+            <sp-button-group style="min-width: max-content">
+                <sp-button variant="secondary">Label only</sp-button>
+                <sp-button variant="secondary">
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                    Icon + Label
+                </sp-button>
+                <sp-button variant="secondary" label="Icon only" icon-only>
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                </sp-button>
+            </sp-button-group>
+        </div>
+
+        <div class="demo-example" style="display: flex">
+            <sp-button-group style="min-width: max-content">
+                <sp-button variant="negative">Label only</sp-button>
+                <sp-button variant="negative">
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                    Icon + Label
+                </sp-button>
+                <sp-button variant="negative" label="Icon only" icon-only>
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                </sp-button>
+            </sp-button-group>
+        </div>
+
+        <div class="demo-example" style="display: flex">
+            <sp-button-group style="min-width: max-content">
+                <sp-button static="black">Label only</sp-button>
+                <sp-button static="black">
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                    Icon + Label
+                </sp-button>
+                <sp-button static="black" label="Icon only" icon-only>
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                </sp-button>
+            </sp-button-group>
+        </div>
+
+        <div class="demo-example" style="display: flex">
+            <sp-button-group style="min-width: max-content">
+                <sp-button static="white">Label only</sp-button>
+                <sp-button static="white">
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                    Icon + Label
+                </sp-button>
+                <sp-button static="white" label="Icon only" icon-only>
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                </sp-button>
+            </sp-button-group>
+        </div>
+
+        <div id="variantLabel">treatment</div>
+        <div class="demo-example" style="display: flex">
+            <sp-button-group style="min-width: max-content">
+                <sp-button treatment="fill" variant="primary">
+                    Primary, Fill
+                </sp-button>
+                <sp-button treatment="fill" variant="secondary">
+                    Secondary, Fill
+                </sp-button>
+                <sp-button treatment="fill" variant="negative">
+                    Negative, Fill
+                </sp-button>
+            </sp-button-group>
+        </div>
+
+        <div class="demo-example" style="display: flex">
+            <sp-button-group style="min-width: max-content">
+                <sp-button treatment="outline" variant="primary">
+                    Primary, Outline
+                </sp-button>
+                <sp-button treatment="outline" variant="secondary">
+                    Secondary, Outline
+                </sp-button>
+                <sp-button treatment="outline" variant="negative">
+                    Negative, Outline
+                </sp-button>
+            </sp-button-group>
+        </div>
+
+        <div class="demo-example" style="display: flex">
+            <sp-button-group
+                style="
+                    background: var(--spectrum-seafoam-600);
+                    padding: 0.5em;
+                    min-width: max-content;
+                "
+            >
+                <sp-button treatment="outline" static="black">
+                    Label only
+                </sp-button>
+                <sp-button treatment="outline" static="black">
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                    Icon + Label
+                </sp-button>
+                <sp-button
+                    treatment="outline"
+                    static="black"
+                    label="Icon only"
+                    icon-only
                 >
-                    <path
-                        d="M16 36a4.407 4.407 0 0 0 4-4h-8a4.407 4.407 0 0 0 4 4zm9.143-24.615c0-3.437-3.206-4.891-7.143-5.268V3a1.079 1.079 0 0 0-1.143-1h-1.714A1.079 1.079 0 0 0 14 3v3.117c-3.937.377-7.143 1.831-7.143 5.268C6.857 26.8 2 26.111 2 28.154V30h28v-1.846C30 26 25.143 26.8 25.143 11.385z"
-                    ></path>
-                </svg>
-                SVG Icon + Label
-            </sp-button>
-            <sp-button variant="accent" style="margin: 10px">Accent</sp-button>
-            <sp-button variant="primary" disabled style="margin: 10px">
-                Disabled
-            </sp-button>
-            <sp-button variant="accent" style="margin: 10px">
-                <sp-icon-display-advert slot="icon"></sp-icon-display-advert>
-                Accent
-            </sp-button>
-            <sp-button variant="negative" style="margin: 10px">
-                <sp-icon-add-to-selection
-                    slot="icon"
-                ></sp-icon-add-to-selection>
-            </sp-button>
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                </sp-button>
+            </sp-button-group>
+        </div>
+
+        <div class="demo-example" style="display: flex">
+            <sp-button-group
+                style="
+                    background: var(--spectrum-seafoam-600);
+                    padding: 0.5em;
+                    min-width: max-content;
+                "
+            >
+                <sp-button treatment="outline" static="white">
+                    Label only
+                </sp-button>
+                <sp-button treatment="outline" static="white">
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                    Icon + Label
+                </sp-button>
+                <sp-button
+                    treatment="outline"
+                    static="white"
+                    label="Icon only"
+                    icon-only
+                >
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                </sp-button>
+            </sp-button-group>
         </div>
     </div>
 

--- a/projects/swc-starter-webpack/src/example_usages/sp-card.html
+++ b/projects/swc-starter-webpack/src/example_usages/sp-card.html
@@ -15,14 +15,257 @@ governing permissions and limitations under the License.
 <div id="content">
     <div id="left">
         <div id="subtitle">sp-card</div>
-        <sp-card heading="Card Heading" subheading="JPG Photo" toggles>
-            <img
-                slot="cover-photo"
-                src="https://picsum.photos/200/300"
-                alt="Demo Image"
-            />
-            <div slot="footer">Footer</div>
-        </sp-card>
+        <div id="variantLabel">slot="cover-photo"</div>
+        <div class="demo-example">
+            <sp-card heading="Card Heading" subheading="JPG Photo">
+                <img
+                    slot="cover-photo"
+                    src="https://picsum.photos/200/300"
+                    alt="Demo Image"
+                />
+                <div slot="footer">Footer</div>
+            </sp-card>
+        </div>
+        <div id="variantLabel">slot="preview"</div>
+        <div class="demo-example">
+            <sp-card heading="Card Title" subheading="JPG">
+                <img
+                    slot="preview"
+                    src="https://picsum.photos/200/300"
+                    alt="Demo Image"
+                />
+                <div slot="footer">Footer</div>
+            </sp-card>
+        </div>
+
+        <div id="variantLabel">heading</div>
+        <div class="demo-example">
+            <sp-card
+                subheading="JPG Photo"
+                style="--spectrum-card-body-header-height: auto"
+            >
+                <h1 slot="heading">Card Heading</h1>
+                <img
+                    alt=""
+                    slot="cover-photo"
+                    src="https://picsum.photos/200/300"
+                />
+                <div slot="footer">Footer</div>
+            </sp-card>
+        </div>
+
+        <div id="variantLabel">linking</div>
+        <div class="demo-example">
+            <sp-card
+                heading="Card Title"
+                subheading="JPG"
+                href="https://opensource.adobe.com/spectrum-web-components"
+                target="_blank"
+            >
+                <img
+                    slot="cover-photo"
+                    src="https://picsum.photos/200/300"
+                    alt="Demo Image"
+                />
+            </sp-card>
+        </div>
+
+        <div id="variantLabel">variant</div>
+        <div class="demo-example">
+            <sp-field-label for="xs">Normal</sp-field-label>
+            <sp-card heading="Card Heading">
+                <img
+                    alt=""
+                    slot="cover-photo"
+                    src="https://picsum.photos/200/300"
+                />
+                <span slot="subheading">JPG photo</span>
+                <div slot="footer">Footer</div>
+            </sp-card>
+        </div>
+        <div class="demo-example">
+            <sp-field-label for="xs">Actions</sp-field-label>
+            <sp-card heading="Card Heading" subheading="JPG Photo">
+                <img
+                    slot="cover-photo"
+                    src="https://picsum.photos/200/300"
+                    alt="Demo Image"
+                />
+                <div slot="footer">Footer</div>
+                <sp-action-menu
+                    label="More Actions"
+                    slot="actions"
+                    placement="bottom-end"
+                    quiet
+                >
+                    <sp-menu-item>Deselect</sp-menu-item>
+                    <sp-menu-item>Select Inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and Mask...</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Save Selection</sp-menu-item>
+                    <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                </sp-action-menu>
+            </sp-card>
+        </div>
+        <div class="demo-example">
+            <sp-field-label for="xs">No Preview Image</sp-field-label>
+            <sp-card heading="Card Title" subheading="No Preview Image">
+                <div slot="footer">Footer</div>
+            </sp-card>
+        </div>
+        <div class="demo-example">
+            <sp-field-label for="xs">Quiet</sp-field-label>
+            <div style="width: 208px; height: 264px">
+                <sp-card
+                    variant="quiet"
+                    heading="Card Heading"
+                    subheading="JPG Photo"
+                >
+                    <img
+                        alt=""
+                        slot="preview"
+                        src="https://picsum.photos/200/300"
+                    />
+                    <div slot="description">10/15/18</div>
+                    <div slot="footer">Footer</div>
+                </sp-card>
+            </div>
+            <sp-field-label for="xs">Quiet + Action</sp-field-label>
+            <div style="width: 208px; height: 264px">
+                <sp-card
+                    variant="quiet"
+                    heading="Card Heading"
+                    subheading="JPG Photo"
+                >
+                    <img
+                        alt=""
+                        slot="preview"
+                        src="https://picsum.photos/200/300"
+                    />
+                    <div slot="description">10/15/18</div>
+                    <sp-action-menu
+                        label="More Actions"
+                        slot="actions"
+                        placement="bottom-end"
+                        quiet
+                    >
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item>Select Inverse</sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and Mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save Selection</sp-menu-item>
+                        <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                    </sp-action-menu>
+                </sp-card>
+            </div>
+        </div>
+
+        <div id="variantLabel">gallery</div>
+        <div class="demo-example">
+            <div style="width: 532px; max-width: 100%; height: 224px">
+                <sp-card
+                    variant="gallery"
+                    heading="Card Heading"
+                    subheading="JPG Photo"
+                >
+                    <img
+                        alt=""
+                        slot="preview"
+                        src="https://picsum.photos/532/192"
+                    />
+                    <div slot="description">10/15/18</div>
+                    <div slot="footer">Footer</div>
+                </sp-card>
+            </div>
+        </div>
+
+        <div id="variantLabel">size-s</div>
+        <div class="demo-example">
+            <sp-field-label for="xs">Default</sp-field-label>
+            <div style="width: 208px; height: 264px">
+                <sp-card size="s" heading="Card Heading" subheading="JPG Photo">
+                    <img
+                        slot="cover-photo"
+                        alt="Demo Image"
+                        src="https://picsum.photos/110"
+                    />
+                    <div slot="footer">Footer</div>
+                </sp-card>
+            </div>
+            <sp-field-label for="xs">horizontal</sp-field-label>
+            <div style="color: var(--spectrum-neutral-content-color-default)">
+                <sp-card
+                    size="s"
+                    horizontal
+                    heading="Card Heading"
+                    subheading="JPG Photo"
+                >
+                    <sp-icon slot="preview" style="width: 36px; height: 36px">
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 36 36"
+                            aria-hidden="true"
+                            role="img"
+                            fill="currentColor"
+                        >
+                            <path d="M20 2v10h10L20 2z" />
+                            <path
+                                d="M19 14a1 1 0 01-1-1V2H7a1 1 0 00-1 1v30a1 1 0 001 1h22a1 1 0 001-1V14zm7 15.5a.5.5 0 01-.5.5h-15a.5.5 0 01-.5-.5v-1a.5.5 0 01.5-.5h15a.5.5 0 01.5.5zm0-4a.5.5 0 01-.5.5h-15a.5.5 0 01-.5-.5v-1a.5.5 0 01.5-.5h15a.5.5 0 01.5.5zm0-4a.5.5 0 01-.5.5h-15a.5.5 0 01-.5-.5v-1a.5.5 0 01.5-.5h15a.5.5 0 01.5.5z"
+                            />
+                        </svg>
+                    </sp-icon>
+                </sp-card>
+            </div>
+            <sp-field-label for="xs">Quiet</sp-field-label>
+            <div
+                style="
+                    color: var(--spectrum-neutral-content-color-default);
+                    width: 110px;
+                "
+            >
+                <sp-card
+                    size="s"
+                    heading="Card Heading"
+                    subheading="JPG Photo"
+                    variant="quiet"
+                >
+                    <img
+                        src="https://picsum.photos/110"
+                        alt="Demo Image"
+                        slot="preview"
+                    />
+                    <div slot="footer">Footer</div>
+                    <sp-action-menu
+                        label="More Actions"
+                        slot="actions"
+                        placement="bottom-end"
+                        quiet
+                    >
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item>Select Inverse</sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and Mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save Selection</sp-menu-item>
+                        <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                    </sp-action-menu>
+                </sp-card>
+            </div>
+        </div>
+
+        <div id="variantLabel">toggles</div>
+        <div class="demo-example">
+            <sp-card heading="Card Heading" subheading="JPG Photo" toggles>
+                <img
+                    slot="cover-photo"
+                    src="https://picsum.photos/200/300"
+                    alt="Demo Image"
+                />
+                <div slot="footer">Footer</div>
+            </sp-card>
+        </div>
     </div>
 
     <div id="right">

--- a/projects/swc-starter-webpack/src/example_usages/sp-checkbox.html
+++ b/projects/swc-starter-webpack/src/example_usages/sp-checkbox.html
@@ -15,28 +15,138 @@ governing permissions and limitations under the License.
 <div id="content">
     <div id="left">
         <div id="subtitle">sp-checkbox</div>
-        <div
-            style="display: flex; justify-content: space-between; width: 500px"
-        >
-            <div style="display: flex; flex-direction: column">
-                <h4 class="spectrum-Heading--subtitle1">Default</h4>
-                <sp-checkbox>Web component</sp-checkbox>
-                <sp-checkbox checked>Web component</sp-checkbox>
-                <sp-checkbox indeterminate>Web component</sp-checkbox>
-            </div>
 
-            <div style="display: flex; flex-direction: column">
-                <h4 class="spectrum-Heading--subtitle1">Invalid</h4>
-                <sp-checkbox invalid>Web component</sp-checkbox>
-                <sp-checkbox checked invalid>Web component</sp-checkbox>
-                <sp-checkbox indeterminate invalid>Web component</sp-checkbox>
-            </div>
+        <div id="variantLabel">sizes</div>
+        <div class="demo-example" style="display: flex">
+            <sp-field-group>
+                <sp-checkbox size="s">Small</sp-checkbox>
+                <sp-checkbox size="s" checked>Small Checked</sp-checkbox>
+                <sp-checkbox size="s" indeterminate>
+                    Small Indeterminate
+                </sp-checkbox>
+            </sp-field-group>
+        </div>
+        <div class="demo-example" style="display: flex">
+            <sp-field-group>
+                <sp-checkbox size="m">Medium</sp-checkbox>
+                <sp-checkbox size="m" checked>Medium Checked</sp-checkbox>
+                <sp-checkbox size="m" indeterminate>
+                    Medium Indeterminate
+                </sp-checkbox>
+            </sp-field-group>
+        </div>
+        <div class="demo-example" style="display: flex">
+            <sp-field-group>
+                <sp-checkbox size="l">Large</sp-checkbox>
+                <sp-checkbox size="l" checked>Large Checked</sp-checkbox>
+                <sp-checkbox size="l" indeterminate>
+                    Large Indeterminate
+                </sp-checkbox>
+            </sp-field-group>
+        </div>
+        <div class="demo-example" style="display: flex">
+            <sp-field-group>
+                <sp-checkbox size="xl">Extra Large</sp-checkbox>
+                <sp-checkbox size="xl" checked>Extra Large Checked</sp-checkbox>
+                <sp-checkbox size="xl" indeterminate>
+                    Extra Large Indeterminate
+                </sp-checkbox>
+            </sp-field-group>
+        </div>
 
-            <div style="display: flex; flex-direction: column">
-                <h4 class="spectrum-Heading--subtitle1">Disabled</h4>
-                <sp-checkbox disabled>Web component</sp-checkbox>
-                <sp-checkbox checked disabled>Web component</sp-checkbox>
-                <sp-checkbox indeterminate disabled>Web component</sp-checkbox>
+        <div id="variantLabel">standard</div>
+        <div class="demo-example" style="display: flex">
+            <div style="display: flex; justify-content: space-between">
+                <div style="display: flex; flex-direction: column">
+                    <h4 class="spectrum-Heading--subtitle1">Default</h4>
+                    <sp-checkbox>Web component</sp-checkbox>
+                    <sp-checkbox checked>Web component</sp-checkbox>
+                    <sp-checkbox indeterminate>Web component</sp-checkbox>
+                </div>
+
+                <div
+                    style="
+                        display: flex;
+                        flex-direction: column;
+                        margin-left: 20px;
+                    "
+                >
+                    <h4 class="spectrum-Heading--subtitle1">Invalid</h4>
+                    <sp-checkbox invalid>Web component</sp-checkbox>
+                    <sp-checkbox checked invalid>Web component</sp-checkbox>
+                    <sp-checkbox indeterminate invalid>
+                        Web component
+                    </sp-checkbox>
+                </div>
+
+                <div
+                    style="
+                        display: flex;
+                        flex-direction: column;
+                        margin-left: 20px;
+                    "
+                >
+                    <h4 class="spectrum-Heading--subtitle1">Disabled</h4>
+                    <sp-checkbox disabled>Web component</sp-checkbox>
+                    <sp-checkbox checked disabled>Web component</sp-checkbox>
+                    <sp-checkbox indeterminate disabled>
+                        Web component
+                    </sp-checkbox>
+                </div>
+            </div>
+        </div>
+
+        <div id="variantLabel">emphasized</div>
+        <div class="demo-example" style="display: flex">
+            <div style="display: flex; justify-content: space-between">
+                <div
+                    style="
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: space-between;
+                    "
+                >
+                    <h4 class="spectrum-Heading--subtitle1">Default</h4>
+                    <sp-checkbox emphasized>Web component</sp-checkbox>
+                    <sp-checkbox emphasized checked>Web component</sp-checkbox>
+                    <sp-checkbox emphasized indeterminate>
+                        Web component
+                    </sp-checkbox>
+                </div>
+
+                <div
+                    style="
+                        display: flex;
+                        flex-direction: column;
+                        margin-left: 20px;
+                    "
+                >
+                    <h4 class="spectrum-Heading--subtitle1">Invalid</h4>
+                    <sp-checkbox emphasized invalid>Web component</sp-checkbox>
+                    <sp-checkbox emphasized checked invalid>
+                        Web component
+                    </sp-checkbox>
+                    <sp-checkbox emphasized indeterminate invalid>
+                        Web component
+                    </sp-checkbox>
+                </div>
+
+                <div
+                    style="
+                        display: flex;
+                        flex-direction: column;
+                        margin-left: 20px;
+                    "
+                >
+                    <h4 class="spectrum-Heading--subtitle1">Disabled</h4>
+                    <sp-checkbox emphasized disabled>Web component</sp-checkbox>
+                    <sp-checkbox emphasized checked disabled>
+                        Web component
+                    </sp-checkbox>
+                    <sp-checkbox emphasized indeterminate disabled>
+                        Web component
+                    </sp-checkbox>
+                </div>
             </div>
         </div>
     </div>

--- a/projects/swc-starter-webpack/src/styles.css
+++ b/projects/swc-starter-webpack/src/styles.css
@@ -158,7 +158,7 @@ p {
     flex: 1 1 0%;
     max-width: 100%;
     overflow: auto;
-    padding: 10px 10px 0px 10px;
+    padding: 10px 10px 10px 10px;
     margin: 10px 10px 0px 0px;
     position: relative;
     z-index: 1;


### PR DESCRIPTION
This PR adresses - 
[UXP-22595](https://jira.corp.adobe.com/browse/UXP-22595) - Support focus-ring and focused state for Spectrum Web Components in UXP with 0.37.0 upgrade
[UXP-22474](https://jira.corp.adobe.com/browse/UXP-22474) - [SWC_Vanilla_v37] [SWC_React_v37] [PS] [Search v37] [Number Field v37]- The focus line is not appearing on fields with  'Quiet' variant. 
[UXP-22447](https://jira.corp.adobe.com/browse/UXP-22447) - [SWC_Vanilla_v37] [PS] [Card]- Tab focus issues in 'Card' component.
[UXP-22510](https://jira.corp.adobe.com/browse/UXP-22510) - [SWC_React_v37] [PS] [Textarea v37]- Extra gaps are still available, after clicking on 'Quiet' switch from control.
[UXP-22539](https://jira.corp.adobe.com/browse/UXP-22539) - [SWC_Vanilla_v37] [SWC_React_v37] [PS] [Action Button v37]- Button is not selectable when using the 'Enter/return' key from keyboard.
[UXP-22566](https://jira.corp.adobe.com/browse/UXP-22566) - [SWC_Vanilla_v37] [SWC_React_v37] [PS] [Textfield v37]- The tab focus is not appearing for ‘Enter your name (quietly)’ text field.