### PR TITLE
[UXP-22650] - Adding appropriate padding-bottom to workaround bottom border trimming

### DIFF
--- a/packages/textfield/src/uxp-textfield.css
+++ b/packages/textfield/src/uxp-textfield.css
@@ -123,7 +123,17 @@ governing permissions and limitations under the License.
             var(
                 --mod-textfield-border-width,
                 var(--spectrum-textfield-border-width)
-            )
+            ) * 2
+    );
+    padding-bottom: calc(
+        var(
+                --mod-textfield-spacing-block-start,
+                var(--spectrum-textfield-spacing-block-start)
+            ) -
+            var(
+                --mod-textfield-border-width,
+                var(--spectrum-textfield-border-width)
+            ) * 2
     );
     padding-left: calc(
         var(


### PR DESCRIPTION
Fixes - https://jira.corp.adobe.com/browse/UXP-22650

**Bug**
<img width="1722" alt="Screenshot 2024-05-17 at 5 16 04 PM" src="https://github.com/adobe/swc-uxp-wrappers/assets/100129259/48927214-0f63-49c2-90c8-bb219f09c81c">

**After Fix** 
_(Windows)_
<img width="1727" alt="Screenshot 2024-05-17 at 5 08 54 PM" src="https://github.com/adobe/swc-uxp-wrappers/assets/100129259/ed3bb3b8-2613-4864-b841-6ae3e6122cbe">


_(Mac)_
<img width="1721" alt="Screenshot 2024-05-17 at 5 11 27 PM" src="https://github.com/adobe/swc-uxp-wrappers/assets/100129259/c826f883-90c8-4596-8552-a9bba9b3ab3e">