### PR TITLE
added dependencies on utils + fixed lint errors

### DIFF
--- a/packages/action-bar/README.md
+++ b/packages/action-bar/README.md
@@ -43,5 +43,7 @@ import { ActionBar } from '@swc-uxp-wrappers/action-bar';
 ```html
 <sp-action-bar></sp-action-bar>
 ```
+
 ## Known issues
-- Sticky variant is not supported
+
+-   Sticky variant is not supported

--- a/packages/asset/README.md
+++ b/packages/asset/README.md
@@ -43,6 +43,7 @@ import { Asset } from '@swc-uxp-wrappers/asset';
 ```html
 <sp-asset></sp-asset>
 ```
-## Known Issues
-- For variant file or folder, one needs to explicitly set height and/or width in the plugin
 
+## Known Issues
+
+-   For variant file or folder, one needs to explicitly set height and/or width in the plugin

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -43,5 +43,7 @@ import { Card } from '@swc-uxp-wrappers/card';
 ```html
 <sp-card></sp-card>
 ```
+
 ## Known Issues
-- `Actions` variant is not supported
+
+-   `Actions` variant is not supported

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -43,5 +43,7 @@ import { Checkbox } from '@swc-uxp-wrappers/checkbox';
 ```html
 <sp-checkbox></sp-checkbox>
 ```
+
 ## Known Issues
-- Tab navigation is not supported
+
+-   Tab navigation is not supported

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -43,5 +43,7 @@ import { Link } from '@swc-uxp-wrappers/link';
 ```html
 <sp-link></sp-link>
 ```
+
 ## Known Issues
-- The double underline does not appear on hyperlinks on tabbing in Windows.
+
+-   The double underline does not appear on hyperlinks on tabbing in Windows.

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -45,6 +45,7 @@ import { Menu } from '@swc-uxp-wrappers/menu';
 ```
 
 ## Known Issues
-- Multi select variant does not work
-- Submenu is not supported
-- Performance issue observed when one clicks multiple times on a menu item
+
+-   Multi select variant does not work
+-   Submenu is not supported
+-   Performance issue observed when one clicks multiple times on a menu item

--- a/packages/meter/README.md
+++ b/packages/meter/README.md
@@ -45,8 +45,6 @@ import { Meter } from '@swc-uxp-wrappers/meter';
 ```
 
 ## Known Issues
-- Duplicate content appears in this way of usage `<sp-meter>Task Status</sp-meter>`, known SWC library issue. 
-    - Workaround : use `<sp-meter label="Task Status"></sp-meter>`
 
-
-
+-   Duplicate content appears in this way of usage `<sp-meter>Task Status</sp-meter>`, known SWC library issue.
+    -   Workaround : use `<sp-meter label="Task Status"></sp-meter>`

--- a/packages/number-field/README.md
+++ b/packages/number-field/README.md
@@ -45,7 +45,8 @@ import { NumberField } from '@swc-uxp-wrappers/number-field';
 ```
 
 ## Known Issues
-- Quiet and Readonly variant has black background for Windows
-- Stepper icons are trimmed with quiet variant in React context
-- On inserting an alphabet in the number field, the cursor moves from the defined place.
-- Font does not adapt to the T-shirt sizing due to limitation of PS/DVA platform
+
+-   Quiet and Readonly variant has black background for Windows
+-   Stepper icons are trimmed with quiet variant in React context
+-   On inserting an alphabet in the number field, the cursor moves from the defined place.
+-   Font does not adapt to the T-shirt sizing due to limitation of PS/DVA platform

--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -43,8 +43,10 @@ import { Overlay } from '@swc-uxp-wrappers/overlay';
 ```html
 <sp-overlay></sp-overlay>
 ```
+
 ## Known Issues
-- Styling of popover and tip rendered is incorrect  when used inside overlay
-- Nested overlay is not supported
-- The toast dissapears when hovered on it inside overlay
-- Longpress attribute does not work with keyboard press event
+
+-   Styling of popover and tip rendered is incorrect when used inside overlay
+-   Nested overlay is not supported
+-   The toast dissapears when hovered on it inside overlay
+-   Longpress attribute does not work with keyboard press event

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -45,9 +45,9 @@ import { Search } from '@swc-uxp-wrappers/search';
 ```
 
 ## Known Issues
-- Black background appears for quiet and readonly variant in windows
-- Close button does not respond on Mac platform
-- Placeholder text is not greyed with `disable` attribute
-- Focus ring is not curved on the corners
-- Font does not adapt to the T-shirt sizing due to limitation of PS/DVA platform
 
+-   Black background appears for quiet and readonly variant in windows
+-   Close button does not respond on Mac platform
+-   Placeholder text is not greyed with `disable` attribute
+-   Focus ring is not curved on the corners
+-   Font does not adapt to the T-shirt sizing due to limitation of PS/DVA platform

--- a/packages/sidenav/README.md
+++ b/packages/sidenav/README.md
@@ -45,5 +45,6 @@ import { Sidenav } from '@swc-uxp-wrappers/sidenav';
 ```
 
 ## Known Issues
-- Tab navigation happens with tab key and not arrow keys
-- `manageTabIndex` attribute is not supported
+
+-   Tab navigation happens with tab key and not arrow keys
+-   `manageTabIndex` attribute is not supported

--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -45,5 +45,6 @@ import { Switch } from '@swc-uxp-wrappers/switch';
 ```
 
 ## Known Issues
-- Tab navigation does not work
-- Line break is seen when switch is used for `scale=large`
+
+-   Tab navigation does not work
+-   Line break is seen when switch is used for `scale=large`

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -43,6 +43,8 @@ import { Table } from '@swc-uxp-wrappers/table';
 ```html
 <sp-table></sp-table>
 ```
+
 ## Known Issues
-- Virtualised table does not work
-- Selects attribute does not work
+
+-   Virtualised table does not work
+-   Selects attribute does not work

--- a/packages/tags/README.md
+++ b/packages/tags/README.md
@@ -43,5 +43,7 @@ import { Tags } from '@swc-uxp-wrappers/tags';
 ```html
 <sp-tags></sp-tags>
 ```
+
 ## Known Issues
-- Avatar do not get greyscaled with disabled attribute
+
+-   Avatar do not get greyscaled with disabled attribute

--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -43,13 +43,14 @@ import { Textfield } from '@swc-uxp-wrappers/textfield';
 ```html
 <sp-textfield></sp-textfield>
 ```
-## Known Issues
-- Focus ring is not curved on the corners
-- On enabling `grows`, `quiet` and `disbaled`, the text is distorted
-- On enabling `grows` attribute on windows, the component layout filckers while typing.
-- Font does not adapt to the T-shirt sizing due to limitation of PS/DVA platform
-- Black background appears for quiet and readonly variant in windows
-- For multiline variant, text value blinks on hovering on windows
-- In windows, after typing text with symbols example `abcdss, efgh@ssss` and on pressing enter results in some text value getting missed on the left side
-- Tab navigation has issues with `type=password`
 
+## Known Issues
+
+-   Focus ring is not curved on the corners
+-   On enabling `grows`, `quiet` and `disbaled`, the text is distorted
+-   On enabling `grows` attribute on windows, the component layout filckers while typing.
+-   Font does not adapt to the T-shirt sizing due to limitation of PS/DVA platform
+-   Black background appears for quiet and readonly variant in windows
+-   For multiline variant, text value blinks on hovering on windows
+-   In windows, after typing text with symbols example `abcdss, efgh@ssss` and on pressing enter results in some text value getting missed on the left side
+-   Tab navigation has issues with `type=password`

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -43,4 +43,3 @@ import { Tooltip } from '@swc-uxp-wrappers/tooltip';
 ```html
 <sp-tooltip></sp-tooltip>
 ```
-

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,6 +23,18 @@
     "files": [
         "**/*.js"
     ],
+    "dependencies": {
+        "@swc-uxp-internal/theme": "npm:@spectrum-web-components/theme@0.37.0",
+        "@swc-uxp-internal/base": "npm:@spectrum-web-components/base@0.37.0",
+        "@swc-uxp-internal/styles": "npm:@spectrum-web-components/styles@0.37.0",
+        "@swc-uxp-internal/shared": "npm:@spectrum-web-components/shared@0.37.0",
+        "@swc-uxp-internal/reactive-controllers": "npm:@spectrum-web-components/reactive-controllers@0.37.0",
+        "@swc-uxp-internal/icon": "npm:@spectrum-web-components/icon@0.37.0",
+        "@swc-uxp-internal/icons": "npm:@spectrum-web-components/icons@0.37.0",
+        "@swc-uxp-internal/iconset": "npm:@spectrum-web-components/iconset@0.37.0",
+        "@swc-uxp-internal/icons-ui": "npm:@spectrum-web-components/icons-ui@0.37.0",
+        "@swc-uxp-internal/icons-workflow": "npm:@spectrum-web-components/icons-workflow@0.37.0"
+    },
     "keywords": [
         "UXP",
         "Spectrum Web Components",


### PR DESCRIPTION
Updated @swc-uxp-wrappers/utils to have dependecies on core packages like theme, shared, styles, icon etc whose separate wrappers do not exist this will help in ease integration of components. 