### PR TITLE
[UXP-22719][UXP-22720] - Added support of SWC sp-action-menu & sp-picker (v0.37.0) in swc-uxp-wrapper for UXP

### DIFF
--- a/packages/action-menu/README.md
+++ b/packages/action-menu/README.md
@@ -1,0 +1,45 @@
+## Description
+
+---
+
+<br />
+This is UXP wrapper for `@spectrum-web-components/action-menu` package 
+<br />
+
+-   For detailed README regarding `@spectrum-web-components/action-menu` [refer this link](https://www.npmjs.com/package/@spectrum-web-components/action-menu/v/0.39.0)
+
+-   Detailed specification regarding `@spectrum-web-components/action-menu` support in UXP through `@swc-uxp-wrappers/action-menu` [refer this link](https://developer.adobe.com/photoshop/uxp/2022/uxp-api/reference-spectrum/swc/)
+
+## Usage
+
+---
+
+<br />
+
+```
+yarn add @swc-uxp-wrappers/action-menu
+```
+
+Import the side effectful registration of `<sp-action-menu>` via:
+
+```
+import '@swc-uxp-wrappers/action-menu/sp-action-menu.js';
+```
+
+When looking to leverage the `ActionMenu` base class as a type and/or for extension purposes, do so via:
+
+```
+import { ActionMenu } from '@swc-uxp-wrappers/action-menu';
+```
+
+<br />
+
+## Example
+
+---
+
+<br />
+
+```html
+<sp-action-menu></sp-action-menu>
+```

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "@swc-uxp-wrappers/action-menu",
+    "version": "1.0.0",
+    "publishConfig": {
+        "access": "public"
+    },
+    "description": "UXP wrapper of the @spectrum-web-components/action-menu component",
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://git.corp.adobe.com/torq/swc-uxp-wrappers.git",
+        "directory": "packages/action-menu"
+    },
+    "author": "Adobe Inc",
+    "main": "src/index.js",
+    "module": "src/index.js",
+    "type": "module",
+    "exports": {
+        ".": "./src/index.js",
+        "./package.json": "./package.json",
+        "./src/ActionMenu.js": "./src/ActionMenu.js",
+        "./src/action-menu.css.js": "./src/action-menu.css.js",
+        "./sp-action-menu.js": "./sp-action-menu.js"
+    },
+    "dependencies": {
+        "@swc-uxp-internal/action-menu": "npm:@spectrum-web-components/action-menu@0.39.0",
+        "@swc-uxp-wrappers/action-button": "*",
+        "@swc-uxp-wrappers/picker": "*"
+    },
+    "files": [
+        "**/*.js"
+    ],
+    "keywords": [
+        "UXP",
+        "Spectrum Web Components",
+        "@spectrum-web-components/action-menu"
+    ]
+}

--- a/packages/action-menu/sp-action-menu.js
+++ b/packages/action-menu/sp-action-menu.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,5 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './aliases.js';
-export * from './MatchMediaController.js';
+import { ActionMenu } from './src/ActionMenu.js';
+
+customElements.define('sp-action-menu', ActionMenu);

--- a/packages/action-menu/src/ActionMenu.js
+++ b/packages/action-menu/src/ActionMenu.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,5 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './aliases.js';
-export * from './MatchMediaController.js';
+import { ActionMenu } from '@swc-uxp-internal/action-menu/src/ActionMenu.js';
+
+import styles from './uxp-action-menu.css.js';
+
+class UxpActionMenu extends ActionMenu {
+    static get styles() {
+        // We are combining our styles to make all super class styles available along with the transitive dependent classes styles.
+        return [super.styles, styles];
+    }
+}
+
+export { UxpActionMenu as ActionMenu };

--- a/packages/action-menu/src/action-menu.css.js
+++ b/packages/action-menu/src/action-menu.css.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,5 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './aliases.js';
-export * from './MatchMediaController.js';
+import { unsafeCSS } from '@spectrum-web-components/base';
+import swcActionMenuStyles from '@swc-uxp-internal/action-menu/src/action-menu.css.js';
+
+import uxpActionMenuStyles from './uxp-action-menu.css.js';
+
+const combinedActionMenuStyles = unsafeCSS(
+    swcActionMenuStyles.toString(),
+    uxpActionMenuStyles.toString()
+);
+
+export default combinedActionMenuStyles;

--- a/packages/action-menu/src/index.js
+++ b/packages/action-menu/src/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,5 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './aliases.js';
-export * from './MatchMediaController.js';
+export * from './ActionMenu.js';

--- a/packages/action-menu/src/uxp-action-menu.css
+++ b/packages/action-menu/src/uxp-action-menu.css
@@ -1,0 +1,52 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* write uxp style overrides */
+
+.icon,
+::slotted([slot='icon']) {
+    margin-right: calc(
+        (
+                var(
+                        --mod-actionbutton-edge-to-text,
+                        var(--spectrum-actionbutton-edge-to-text)
+                    ) -
+                    var(
+                        --mod-actionbutton-edge-to-visual-only,
+                        var(--spectrum-actionbutton-edge-to-visual-only)
+                    )
+            ) * 2
+    );
+}
+
+slot[icon-only] .icon,
+slot[icon-only]::slotted([slot='icon']) {
+    margin-right: 0px;
+}
+
+.dialog[actual-placement*='bottom'] {
+    padding-top: var(--swc-overlay-animation-distance);
+}
+
+:host([selects]) ::slotted(sp-menu-item) {
+    padding-left: var(
+        --mod-menu-item-selectable-edge-to-text-not-selected,
+        var(--spectrum-menu-item-selectable-edge-to-text-not-selected)
+    );
+}
+
+:host([selects]) ::slotted(sp-menu-item[selected]) {
+    padding-left: var(
+        --mod-menu-item-label-inline-edge-to-content,
+        var(--spectrum-menu-item-label-inline-edge-to-content)
+    );
+}

--- a/packages/overlay/src/uxp-overlay.css
+++ b/packages/overlay/src/uxp-overlay.css
@@ -16,3 +16,8 @@ governing permissions and limitations under the License.
 .dialog {
     z-index: 1000;
 }
+
+.dialog[actual-placement*='bottom'] {
+    padding-top: var(--swc-overlay-animation-distance);
+    padding-bottom: var(--swc-overlay-animation-distance);
+}

--- a/packages/picker/README.md
+++ b/packages/picker/README.md
@@ -1,0 +1,45 @@
+## Description
+
+---
+
+<br />
+This is UXP wrapper for `@spectrum-web-components/picker` package 
+<br />
+
+-   For detailed README regarding `@spectrum-web-components/picker` [refer this link](https://www.npmjs.com/package/@spectrum-web-components/picker/v/0.37.0)
+
+-   Detailed specification regarding `@spectrum-web-components/picker` support in UXP through `@swc-uxp-wrappers/picker` [refer this link](https://developer.adobe.com/photoshop/uxp/2022/uxp-api/reference-spectrum/swc/)
+
+## Usage
+
+---
+
+<br />
+
+```
+yarn add @swc-uxp-wrappers/picker
+```
+
+Import the side effectful registration of `<sp-picker>` via:
+
+```
+import '@swc-uxp-wrappers/picker/sp-picker.js';
+```
+
+When looking to leverage the `Picker` base class as a type and/or for extension purposes, do so via:
+
+```
+import { Picker } from '@swc-uxp-wrappers/picker';
+```
+
+<br />
+
+## Example
+
+---
+
+<br />
+
+```html
+<sp-picker></sp-picker>
+```

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -1,0 +1,40 @@
+{
+    "name": "@swc-uxp-wrappers/picker",
+    "version": "1.0.0",
+    "publishConfig": {
+        "access": "public"
+    },
+    "description": "UXP wrapper of the @spectrum-web-components/picker component",
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://git.corp.adobe.com/torq/swc-uxp-wrappers.git",
+        "directory": "packages/picker"
+    },
+    "author": "Adobe Inc",
+    "main": "src/index.js",
+    "module": "src/index.js",
+    "type": "module",
+    "exports": {
+        ".": "./src/index.js",
+        "./package.json": "./package.json",
+        "./src/Picker.js": "./src/Picker.js",
+        "./src/picker.css.js": "./src/picker.css.js",
+        "./sp-picker.js": "./sp-picker.js"
+    },
+    "dependencies": {
+        "@swc-uxp-internal/picker": "npm:@spectrum-web-components/picker@0.37.0",
+        "@swc-uxp-wrappers/button": "*",
+        "@swc-uxp-wrappers/menu": "*",
+        "@swc-uxp-wrappers/overlay": "*",
+        "@swc-uxp-wrappers/popover": "*"
+    },
+    "files": [
+        "**/*.js"
+    ],
+    "keywords": [
+        "UXP",
+        "Spectrum Web Components",
+        "@spectrum-web-components/picker"
+    ]
+}

--- a/packages/picker/sp-picker.js
+++ b/packages/picker/sp-picker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,5 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './aliases.js';
-export * from './MatchMediaController.js';
+import { Picker } from './src/Picker.js';
+
+customElements.define('sp-picker', Picker);

--- a/packages/picker/src/Picker.js
+++ b/packages/picker/src/Picker.js
@@ -1,0 +1,114 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { PickerBase } from '@swc-uxp-internal/picker/src/Picker.js';
+import { html } from '@spectrum-web-components/base';
+import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
+import pickerStyles from '@swc-uxp-internal/picker/src/picker.css.js';
+import chevronStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron.css.js';
+
+import uxpStyles from './uxp-picker.css.js';
+
+class UxpPickerBase extends PickerBase {
+    render() {
+        super.render();
+        return html`
+            <span
+                id="focus-helper"
+                tabindex="${this.focused || this.open ? '-1' : '0'}"
+                @focus=${this.handleHelperFocus}
+            ></span>
+            <div
+                aria-haspopup="true"
+                aria-controls=${ifDefined(this.open ? 'menu' : void 0)}
+                aria-expanded=${this.open ? 'true' : 'false'}
+                aria-labelledby="icon label applied-label"
+                id="button"
+                class="button"
+                @blur=${this.handleButtonBlur}
+                @pointerdown=${this.handlebuttonPointerdown}
+                @focus=${this.handleButtonFocus}
+                @click=${this.handleButtonClick}
+                @keydown=${{
+                    handleEvent: this.handleEnterKeydown,
+                    capture: true,
+                }}
+                ?disabled=${this.disabled}
+                tabindex="-1"
+            >
+                ${this.buttonContent}
+            </div>
+            ${this.renderMenu}
+        `;
+    }
+}
+
+export { UxpPickerBase as PickerBase };
+
+class UxpPicker extends UxpPickerBase {
+    constructor() {
+        super(...arguments);
+        this.handleKeydown = (event) => {
+            const { code } = event;
+
+            if (
+                event.code === 'Enter' ||
+                event.code === 'Space' ||
+                code === 'ArrowUp' ||
+                code === 'ArrowDown'
+            ) {
+                this.toggle(true);
+                if (this.open && this.optionsMenu) {
+                    this.optionsMenu.focus();
+                }
+                return;
+            }
+            if (!code.startsWith('Arrow') || this.readonly) {
+                return;
+            }
+            event.preventDefault();
+            const selectedIndex = this.selectedItem
+                ? this.menuItems.indexOf(this.selectedItem)
+                : -1;
+            const nextOffset = !this.value || code === 'ArrowRight' ? 1 : -1;
+            let nextIndex = selectedIndex + nextOffset;
+            while (
+                this.menuItems[nextIndex] &&
+                this.menuItems[nextIndex].disabled
+            ) {
+                nextIndex += nextOffset;
+            }
+            if (
+                !this.menuItems[nextIndex] ||
+                this.menuItems[nextIndex].disabled
+            ) {
+                return;
+            }
+            if (!this.value || nextIndex !== selectedIndex) {
+                this.setValueFromItem(this.menuItems[nextIndex]);
+            }
+        };
+    }
+
+    static get styles() {
+        // We are combining our styles to make all super class styles available along with the transitive dependent classes styles.
+        return [pickerStyles, chevronStyles, uxpStyles];
+    }
+    get containerStyles() {
+        const styles = super.containerStyles;
+        if (!this.quiet) {
+            styles['min-width'] = `${this.offsetWidth}px`;
+        }
+        return styles;
+    }
+}
+export { UxpPicker as Picker };

--- a/packages/picker/src/index.js
+++ b/packages/picker/src/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,5 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './aliases.js';
-export * from './MatchMediaController.js';
+export * from './Picker.js';

--- a/packages/picker/src/picker.css.js
+++ b/packages/picker/src/picker.css.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,5 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './aliases.js';
-export * from './MatchMediaController.js';
+import { unsafeCSS } from '@spectrum-web-components/base';
+import swcPickerStyles from '@swc-uxp-internal/picker/src/picker.css.js';
+
+import uxpPickerStyles from './uxp-picker.css.js';
+
+const combinedPickerStyles = unsafeCSS(
+    swcPickerStyles.toString(),
+    uxpPickerStyles.toString()
+);
+
+export default combinedPickerStyles;

--- a/packages/picker/src/uxp-picker.css
+++ b/packages/picker/src/uxp-picker.css
@@ -1,0 +1,206 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* write uxp style overrides */
+
+#button {
+    height: var(--mod-picker-block-size, var(--spectrum-picker-block-size));
+    max-width: 100%;
+    min-width: calc(
+        var(--spectrum-picker-minimum-width-multiplier) *
+            var(--mod-picker-block-size, var(--spectrum-picker-block-size))
+    );
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-right: var(
+        --mod-picker-spacing-edge-to-disclosure-icon,
+        var(--spectrum-picker-spacing-edge-to-disclosure-icon)
+    );
+    padding-left: var(
+        --mod-picker-spacing-edge-to-text,
+        var(--spectrum-picker-spacing-edge-to-text)
+    );
+    appearance: none;
+}
+
+#button:after {
+    height: calc(
+        100% +
+            var(
+                --mod-picker-focus-indicator-gap,
+                var(--spectrum-picker-focus-indicator-gap)
+            ) * 4 +
+            var(--mod-picker-border-width, var(--spectrum-picker-border-width)) *
+            2
+    );
+    width: calc(
+        100% +
+            var(
+                --mod-picker-focus-indicator-gap,
+                var(--spectrum-picker-focus-indicator-gap)
+            ) * 4 +
+            var(--mod-picker-border-width, var(--spectrum-picker-border-width)) *
+            2
+    );
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin-top: calc(
+        (
+                var(
+                        --mod-picker-focus-indicator-gap,
+                        var(--spectrum-picker-focus-indicator-gap)
+                    ) +
+                    var(
+                        --mod-picker-focus-indicator-thickness,
+                        var(--spectrum-picker-focus-indicator-thickness)
+                    ) +
+                    var(
+                        --mod-picker-border-width,
+                        var(--spectrum-picker-border-width)
+                    )
+            ) * -1
+    );
+    margin-left: calc(
+        (
+                var(
+                        --mod-picker-focus-indicator-gap,
+                        var(--spectrum-picker-focus-indicator-gap)
+                    ) +
+                    var(
+                        --mod-picker-focus-indicator-thickness,
+                        var(--spectrum-picker-focus-indicator-thickness)
+                    ) +
+                    var(
+                        --mod-picker-border-width,
+                        var(--spectrum-picker-border-width)
+                    )
+            ) * -1
+    );
+}
+
+#label ~ .picker {
+    margin-left: var(
+        --mod-picker-spacing-text-to-icon,
+        var(--spectrum-picker-spacing-text-to-icon)
+    );
+}
+
+.picker {
+    margin-top: var(
+        --mod-picker-spacing-top-to-disclosure-icon,
+        var(--spectrum-picker-spacing-top-to-disclosure-icon)
+    );
+    margin-bottom: var(
+        --mod-picker-spacing-top-to-disclosure-icon,
+        var(--spectrum-picker-spacing-top-to-disclosure-icon)
+    );
+    margin-left: var(
+        --mod-picker-spacing-icon-to-disclosure-icon,
+        var(--spectrum-picker-spacing-icon-to-disclosure-icon)
+    );
+}
+
+:host([quiet]) #button {
+    margin-top: calc(
+        var(
+                --mod-picker-spacing-label-to-picker-quiet,
+                var(--spectrum-picker-spacing-label-to-picker-quiet)
+            ) + 1px
+    );
+    padding-left: var(
+        --mod-picker-spacing-edge-to-text-quiet,
+        var(--spectrum-picker-spacing-edge-to-text-quiet)
+    );
+    padding-right: var(
+        --mod-picker-spacing-edge-to-text-quiet,
+        var(--spectrum-picker-spacing-edge-to-text-quiet)
+    );
+}
+
+:host([quiet]) #button {
+    width: auto;
+    min-width: 0;
+}
+
+#menu ::slotted(sp-menu-item) {
+    padding-left: var(
+        --mod-menu-item-selectable-edge-to-text-not-selected,
+        var(--spectrum-menu-item-selectable-edge-to-text-not-selected)
+    );
+}
+
+#menu ::slotted(sp-menu-item[selected]) {
+    padding-left: var(
+        --mod-menu-item-label-inline-edge-to-content,
+        var(--spectrum-menu-item-label-inline-edge-to-content)
+    );
+}
+
+#button .spectrum-ProgressCircle,
+.validation-icon {
+    margin-left: var(
+        --mod-picker-spacing-text-to-alert-icon-inline-start,
+        var(--spectrum-picker-spacing-text-to-alert-icon-inline-start)
+    );
+}
+
+.icon {
+    margin-right: var(
+        --mod-picker-spacing-text-to-icon,
+        var(--spectrum-picker-spacing-text-to-icon)
+    );
+}
+
+.visually-hidden {
+    position: relative;
+}
+
+#button:disabled,
+:host([disabled]) #button {
+    pointer-events: none;
+}
+
+#button.focus-visible:after,
+:host([focused]) #button:after {
+    border-color: transparent;
+}
+
+#button.focus-visible:after {
+    border-color: var(
+        --highcontrast-picker-focus-indicator-color,
+        var(
+            --mod-picker-focus-indicator-color,
+            var(--spectrum-picker-focus-indicator-color)
+        )
+    ) !important;
+}
+
+:host([quiet]) #button:focus-visible:after,
+:host([quiet][focused]) #button:after {
+    box-shadow: none;
+}
+
+:host([quiet].focus-visible) {
+    border-bottom: var(--spectrum-picker-focus-indicator-thickness) solid
+        var(--spectrum-picker-focus-indicator-color);
+}
+
+.visually-hidden {
+    visibility: hidden;
+}
+
+#button:disabled #label.placeholder,
+:host([disabled]) #button #label.placeholder {
+    color: var(--spectrum-picker-font-color-disabled) !important;
+}

--- a/packages/picker/src/uxp-picker.css
+++ b/packages/picker/src/uxp-picker.css
@@ -196,10 +196,6 @@ governing permissions and limitations under the License.
         var(--spectrum-picker-focus-indicator-color);
 }
 
-.visually-hidden {
-    visibility: hidden;
-}
-
 #button:disabled #label.placeholder,
 :host([disabled]) #button #label.placeholder {
     color: var(--spectrum-picker-font-color-disabled) !important;

--- a/packages/popover/src/uxp-popover.css
+++ b/packages/popover/src/uxp-popover.css
@@ -34,7 +34,3 @@ governing permissions and limitations under the License.
     height: 100%;
     width: 10px;
 }
-
-::slotted(.visually-hidden) {
-    visibility: hidden;
-}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,8 @@
     "exports": {
         ".": "./src/index.js",
         "./package.json": "./package.json",
-        "./src/aliases.js": "./src/aliases.js"
+        "./src/aliases.js": "./src/aliases.js",
+        "./src/MatchMediaController.js": "./src/MatchMediaController.js"
     },
     "files": [
         "**/*.js"

--- a/packages/utils/src/MatchMediaController.js
+++ b/packages/utils/src/MatchMediaController.js
@@ -10,31 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-/* write uxp style overrides */
-
-/* Workaround for - https://jira.corp.adobe.com/browse/UXP-21331 */
-:host {
-    --uxp-swc-horizontal-offset: 0px;
-    --uxp-swc-vertical-offset: 2px;
-    --uxp-swc-blur: 6px;
-    box-shadow: var(--uxp-swc-horizontal-offset) var(--uxp-swc-vertical-offset)
-        var(--uxp-swc-blur)
-        var(
-            --spectrum-popover-shadow-color,
-            var(--spectrum-alias-dropshadow-color)
-        );
+// Custom  MatchMediaController
+export function MatchMediaController(context, isMobile) {
+    return false;
 }
-
-.block {
-    height: 10px;
-    width: 100%;
-}
-
-.inline {
-    height: 100%;
-    width: 10px;
-}
-
-::slotted(.visually-hidden) {
-    visibility: hidden;
-}
+export const IS_MOBILE = false;

--- a/packages/utils/src/MatchMediaController.js
+++ b/packages/utils/src/MatchMediaController.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,7 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-// Custom  MatchMediaController
+/* 
+Custom  MatchMediaController Implementation.
+MatchMediaController is a class in reactive-controllers conponent of SWC - https://opensource.adobe.com/spectrum-web-components/tools/match-media/
+which deploys window.matchMedia(query) to accompalish various tasks, one among that is to find a mobile platform/screen and based on that rendering sp-picker or sp-tray.
+since UXP lacks support of window.matchMedia, we have written this custom implementation to overcome missing support in UXP.
+Also, UXP targets desktop application we can safely return false as mobile is not a use-case for UXP.
+*/
+
 export function MatchMediaController(context, isMobile) {
     return false;
 }

--- a/packages/utils/src/aliases.js
+++ b/packages/utils/src/aliases.js
@@ -50,6 +50,10 @@ export const aliases = {
     '@spectrum-web-components/sidenav': '@swc-uxp-wrappers/sidenav',
     '@spectrum-web-components/swatch': '@swc-uxp-wrappers/swatch',
     '@spectrum-web-components/overlay': '@swc-uxp-wrappers/overlay',
+    '@spectrum-web-components/picker': '@swc-uxp-wrappers/picker',
+    '@spectrum-web-components/action-menu': '@swc-uxp-wrappers/action-menu',
+    '@spectrum-web-components/reactive-controllers/src/MatchMedia.js':
+        '@swc-uxp-wrappers/utils/src/MatchMediaController.js',
     '../sp-menu.dev.js': '@swc-uxp-wrappers/menu/sp-menu.js',
     '../sp-menu.js': '@swc-uxp-wrappers/menu/sp-menu.js',
 };

--- a/projects/swc-starter-webpack/src/attach-event-helper.js
+++ b/projects/swc-starter-webpack/src/attach-event-helper.js
@@ -165,6 +165,78 @@ function attachEvents(tabName) {
 
         eval(offsetListener);
     }
+
+    if (tabName === 'sp-action-menu') {
+        const actionMenuValue = `
+            const actionMenu = document.getElementById("action-menu-single-select");
+            actionMenu.addEventListener("change", () => {
+                actionMenu.previousElementSibling.querySelector('#single-value').textContent=actionMenu.value;
+            });
+        `;
+        eval(actionMenuValue);
+    }
+
+    if (tabName === 'sp-picker') {
+        const spPickerSizes = `
+            const sizes = document.getElementById('picker-sizes');
+            sizes.addEventListener("change", () => {
+                document.querySelector('#dynamic-api-test').setAttribute('size', sizes.value); 
+            });
+        `;
+        eval(spPickerSizes);
+
+        const spPickerDisabled = `
+            document.querySelector('#disabled').addEventListener('change', (evt) => {
+                    const checked = evt.target.checked;
+                    const picker = document.querySelector('#dynamic-api-test');
+                    if (checked) {
+                        picker.setAttribute("disabled", "disabled");
+                    } else {
+                        picker.removeAttribute("disabled");
+                    }
+                });
+        `;
+        eval(spPickerDisabled);
+
+        const spPickerQuiet = `
+            document.querySelector('#quiet').addEventListener('change', (evt) => {
+                    const checked = evt.target.checked;
+                    const picker = document.querySelector('#dynamic-api-test');
+                    if (checked) {
+                        picker.setAttribute("quiet", "quiet");
+                    } else {
+                        picker.removeAttribute("quiet");
+                    }
+                });
+        `;
+        eval(spPickerQuiet);
+
+        const spPickerInvalid = `
+            document.querySelector('#invalid').addEventListener('change', (evt) => {
+                    const checked = evt.target.checked;
+                    const picker = document.querySelector('#dynamic-api-test');
+                    if (checked) {
+                        picker.setAttribute("invalid", "invalid");
+                    } else {
+                        picker.removeAttribute("invalid");
+                    }
+                });
+        `;
+        eval(spPickerInvalid);
+
+        const spPickerReadonly = `
+            document.querySelector('#readonly').addEventListener('change', (evt) => {
+                    const checked = evt.target.checked;
+                    const picker = document.querySelector('#dynamic-api-test');
+                    if (checked) {
+                        picker.setAttribute("readonly", "readonly");
+                    } else {
+                        picker.removeAttribute("readonly");
+                    }
+                });
+        `;
+        eval(spPickerReadonly);
+    }
 }
 
 function handleThemeColor(selectObject) {

--- a/projects/swc-starter-webpack/src/example_usages/sp-action-menu.html
+++ b/projects/swc-starter-webpack/src/example_usages/sp-action-menu.html
@@ -1,0 +1,279 @@
+<!-- 
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. 
+-->
+
+<h3>sp-action-menu</h3>
+
+<div id="content">
+    <div id="playground">
+        <div id="left">
+            <div id="subtitle">sp-action-menu</div>
+
+            <div id="variantLabel">sizes</div>
+            <div class="demo-example" style="display: flex">
+                <div class="size-div" style="display: block">
+                    <sp-field-label for="s">Small</sp-field-label>
+                    <sp-action-menu size="s">
+                        <span slot="label">More Actions</span>
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item>Select inverse</sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save selection</sp-menu-item>
+                        <sp-menu-item disabled>Make work path</sp-menu-item>
+                    </sp-action-menu>
+                </div>
+
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <sp-field-label for="m">Medium</sp-field-label>
+                    <sp-action-menu size="m">
+                        <span slot="label">More Actions</span>
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item>Select inverse</sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save selection</sp-menu-item>
+                        <sp-menu-item disabled>Make work path</sp-menu-item>
+                    </sp-action-menu>
+                </div>
+
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <sp-field-label for="L">Large</sp-field-label>
+                    <sp-action-menu size="l">
+                        <span slot="label">More Actions</span>
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item>Select inverse</sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save selection</sp-menu-item>
+                        <sp-menu-item disabled>Make work path</sp-menu-item>
+                    </sp-action-menu>
+                </div>
+
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <sp-field-label for="XL">Extra large</sp-field-label>
+                    <sp-action-menu size="xl">
+                        <span slot="label">More Actions</span>
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item>Select inverse</sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save selection</sp-menu-item>
+                        <sp-menu-item disabled>Make work path</sp-menu-item>
+                    </sp-action-menu>
+                </div>
+            </div>
+            <div id="variantLabel">open</div>
+            <div class="demo-example" style="display: flex">
+                <sp-action-menu size="m" open>
+                    <span slot="label">More Actions</span>
+                    <sp-menu-item>Deselect</sp-menu-item>
+                    <sp-menu-item>Select inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and mask...</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Save selection</sp-menu-item>
+                    <sp-menu-item disabled>Make work path</sp-menu-item>
+                </sp-action-menu>
+            </div>
+            <div id="variantLabel">no icon</div>
+            <div class="demo-example" style="display: flex">
+                <sp-action-menu>
+                    <span slot="label-only">More Actions</span>
+                    <sp-menu-item>Deselect</sp-menu-item>
+                    <sp-menu-item>Select inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and mask...</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Save selection</sp-menu-item>
+                    <sp-menu-item disabled>Make work path</sp-menu-item>
+                </sp-action-menu>
+            </div>
+
+            <div id="variantLabel">no label</div>
+            <div class="demo-example" style="display: flex">
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <sp-action-menu label="More Actions">
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item>Select inverse</sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save selection</sp-menu-item>
+                        <sp-menu-item disabled>Make work path</sp-menu-item>
+                    </sp-action-menu>
+                </div>
+            </div>
+
+            <div id="variantLabel">alternate icon</div>
+            <div class="demo-example" style="display: flex">
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <sp-action-menu>
+                        <sp-icon-settings slot="icon"></sp-icon-settings>
+                        <span slot="label">Actions under the gear</span>
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item>Select inverse</sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save selection</sp-menu-item>
+                        <sp-menu-item disabled>Make work path</sp-menu-item>
+                    </sp-action-menu>
+                </div>
+            </div>
+
+            <div id="variantLabel">alternate icon & no label</div>
+            <div class="demo-example" style="display: flex">
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <sp-action-menu>
+                        <sp-icon-settings slot="icon"></sp-icon-settings>
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item>Select inverse</sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save selection</sp-menu-item>
+                        <sp-menu-item disabled>Make work path</sp-menu-item>
+                    </sp-action-menu>
+                </div>
+            </div>
+
+            <div id="variantLabel">quiet</div>
+            <div class="demo-example" style="display: flex">
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <sp-action-menu size="m" quiet>
+                        <span slot="label">More Actions</span>
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item>Select inverse</sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save selection</sp-menu-item>
+                        <sp-menu-item disabled>Make work path</sp-menu-item>
+                    </sp-action-menu>
+                </div>
+            </div>
+
+            <div id="variantLabel">group with select</div>
+            <div class="demo-example" style="display: flex">
+                <sp-action-menu label="Filter or Sort">
+                    <sp-menu-group selects="single">
+                        <span slot="header">Sort By</span>
+                        <sp-menu-item>Name</sp-menu-item>
+                        <sp-menu-item>Created</sp-menu-item>
+                        <sp-menu-item>Modified</sp-menu-item>
+                    </sp-menu-group>
+                    <sp-menu-divider size="m"></sp-menu-divider>
+                    <sp-menu-group selects="multiple">
+                        <sp-menu-item>Reverse Order</sp-menu-item>
+                    </sp-menu-group>
+                </sp-action-menu>
+            </div>
+
+            <div id="variantLabel">sub-menu</div>
+            <div class="demo-example" style="display: flex">
+                <sp-action-menu label="More Actions">
+                    <sp-menu-item>One</sp-menu-item>
+                    <sp-menu-item>Two</sp-menu-item>
+                    <sp-menu-item>
+                        Select some items
+                        <sp-menu slot="submenu" selects="multiple">
+                            <sp-menu-item>A</sp-menu-item>
+                            <sp-menu-item>B</sp-menu-item>
+                            <sp-menu-item>C</sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                </sp-action-menu>
+            </div>
+
+            <div id="variantLabel">tootip in action menu</div>
+            <div class="demo-example" style="display: flex">
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <sp-action-menu>
+                        <sp-tooltip
+                            slot="tooltip"
+                            self-managed
+                            placement="bottom"
+                        >
+                            Content
+                        </sp-tooltip>
+                        <span slot="label">Available shapes</span>
+                        <sp-menu-item value="shape-1-square">
+                            Square
+                        </sp-menu-item>
+                        <sp-menu-item value="shape-2-triangle">
+                            Triangle
+                        </sp-menu-item>
+                        <sp-menu-item value="shape-3-parallelogram">
+                            Parallelogram
+                        </sp-menu-item>
+                    </sp-action-menu>
+                </div>
+            </div>
+
+            <div id="variantLabel">selection</div>
+            <div class="demo-example" style="display: flex">
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <p>
+                        The value of the `&lt;sp-action-menu&gt;` element is:
+                        <span id="single-value"></span>
+                    </p>
+                    <sp-action-menu
+                        id="action-menu-single-select"
+                        selects="single"
+                    >
+                        <span slot="label">Available shapes</span>
+                        <sp-menu-item value="shape-1-square">
+                            Square
+                        </sp-menu-item>
+                        <sp-menu-item value="shape-2-triangle">
+                            Triangle
+                        </sp-menu-item>
+                        <sp-menu-item value="shape-3-parallelogram">
+                            Parallelogram
+                        </sp-menu-item>
+                        <sp-menu-item value="shape-4-star">Star</sp-menu-item>
+                        <sp-menu-item value="shape-5-hexagon">
+                            Hexagon
+                        </sp-menu-item>
+                        <sp-menu-item value="shape-6-circle" disabled>
+                            Circle
+                        </sp-menu-item>
+                    </sp-action-menu>
+                </div>
+            </div>
+        </div>
+        <input type="text" style="width: 2px" />
+        <div id="right">
+            <div id="subtitle">my-action-menu</div>
+            <my-action-menu>
+                <span slot="label">More Actions</span>
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save selection</sp-menu-item>
+                <sp-menu-item disabled>Make work path</sp-menu-item>
+            </my-action-menu>
+        </div>
+    </div>
+
+    <div id="config">
+        <div style="display: inline-flex"></div>
+
+        <div style="display: flex; flex-direction: column"></div>
+    </div>
+</div>

--- a/projects/swc-starter-webpack/src/example_usages/sp-action-menu.html
+++ b/projects/swc-starter-webpack/src/example_usages/sp-action-menu.html
@@ -75,19 +75,6 @@ governing permissions and limitations under the License.
                     </sp-action-menu>
                 </div>
             </div>
-            <div id="variantLabel">open</div>
-            <div class="demo-example" style="display: flex">
-                <sp-action-menu size="m" open>
-                    <span slot="label">More Actions</span>
-                    <sp-menu-item>Deselect</sp-menu-item>
-                    <sp-menu-item>Select inverse</sp-menu-item>
-                    <sp-menu-item>Feather...</sp-menu-item>
-                    <sp-menu-item>Select and mask...</sp-menu-item>
-                    <sp-menu-divider></sp-menu-divider>
-                    <sp-menu-item>Save selection</sp-menu-item>
-                    <sp-menu-item disabled>Make work path</sp-menu-item>
-                </sp-action-menu>
-            </div>
             <div id="variantLabel">no icon</div>
             <div class="demo-example" style="display: flex">
                 <sp-action-menu>

--- a/projects/swc-starter-webpack/src/example_usages/sp-picker.html
+++ b/projects/swc-starter-webpack/src/example_usages/sp-picker.html
@@ -1,0 +1,1016 @@
+<!-- 
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. 
+-->
+
+<h3>sp-picker</h3>
+
+<div id="content">
+    <div id="playground">
+        <div id="left">
+            <div id="subtitle">sp-picker</div>
+
+            <div class="demo-example" style="display: flex">
+                <div class="size-div" style="display: block">
+                    <div id="variantLabel">Small</div>
+                    <sp-field-group>
+                        <div class="variantDiv">
+                            <sp-field-label for="picker-s" size="s">
+                                Dafault
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-s"
+                                size="s"
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label for="picker-disabled-s" size="s">
+                                Dafault|Disabled
+                            </sp-field-label>
+                            <sp-picker
+                                disabled
+                                id="picker-disabled-s"
+                                size="s"
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label for="picker-s-quiet" size="s">
+                                Quiet
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-s-quiet"
+                                quiet
+                                size="s"
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                for="picker-disabled-s-quiet"
+                                size="s"
+                            >
+                                Quiet|Disabled
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-disabled-s-quiet"
+                                quiet
+                                size="s"
+                                disabled
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label size="s" for="picker-invalid">
+                                Invalid
+                            </sp-field-label>
+                            <sp-picker
+                                size="s"
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                id="picker-invalid"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                size="s"
+                                for="picker-disabled-invalid"
+                            >
+                                Invalid|Disabled
+                            </sp-field-label>
+                            <sp-picker
+                                size="s"
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                disabled
+                                id="picker-disabled-invalid"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label size="s" for="picker-invalid-quiet">
+                                Quiet|Invalid
+                            </sp-field-label>
+                            <sp-picker
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                quiet
+                                size="s"
+                                id="picker-invalid-quiet"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                size="s"
+                                for="picker-disabled-invalid-quiet"
+                            >
+                                Quiet|Disabled
+                            </sp-field-label>
+                            <sp-picker
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                quiet
+                                disabled
+                                size="s"
+                                id="picker-disabled-invalid-quiet"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                    </sp-field-group>
+                </div>
+
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <div id="variantLabel">Medium</div>
+                    <sp-field-group>
+                        <div class="variantDiv">
+                            <sp-field-label for="dynamic-api-test" size="m">
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="dynamic-api-test"
+                                size="m"
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label for="picker-disabled-m" size="m">
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-disabled-m"
+                                size="m"
+                                disabled
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label for="picker-m-quiet" size="m">
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-m-quiet"
+                                quiet
+                                size="m"
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                for="picker-disabled-m-quiet"
+                                size="m"
+                            >
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-disabled-m-quiet"
+                                quiet
+                                size="m"
+                                disabled
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label size="m" for="picker-invalid-m">
+                                Standard:
+                            </sp-field-label>
+                            <sp-picker
+                                size="m"
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                id="picker-invalid-m"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                size="m"
+                                for="picker-disabled-invalid-m"
+                            >
+                                Standard:
+                            </sp-field-label>
+                            <sp-picker
+                                size="m"
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                disabled
+                                id="picker-disabled-invalid-m"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                size="m"
+                                for="picker-invalid-quiet-m"
+                            >
+                                Quiet:
+                            </sp-field-label>
+                            <sp-picker
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                quiet
+                                size="m"
+                                id="picker-invalid-quiet-m"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                size="m"
+                                for="picker-disabled-invalid-quiet-m"
+                            >
+                                Quiet:
+                            </sp-field-label>
+                            <sp-picker
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                quiet
+                                disabled
+                                size="m"
+                                id="picker-disabled-invalid-quiet-m"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                    </sp-field-group>
+                </div>
+
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <div id="variantLabel">Large</div>
+                    <sp-field-group>
+                        <div class="variantDiv">
+                            <sp-field-label for="picker-l" size="l">
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-l"
+                                size="l"
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label for="picker-disabled-l" size="l">
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-disabled-l"
+                                size="l"
+                                disabled
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label for="picker-l-quiet" size="l">
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-l-quiet"
+                                quiet
+                                size="l"
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                for="picker-disabled-l-quiet"
+                                size="l"
+                            >
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-disabled-l-quiet"
+                                quiet
+                                disabled
+                                size="l"
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label size="l" for="picker-invalid-l">
+                                Standard:
+                            </sp-field-label>
+                            <sp-picker
+                                size="l"
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                id="picker-invalid-l"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                size="l"
+                                for="picker-disabled-invalid-l"
+                            >
+                                Standard:
+                            </sp-field-label>
+                            <sp-picker
+                                size="l"
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                disabled
+                                id="picker-disabled-invalid-l"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                size="l"
+                                for="picker-invalid-quiet-l"
+                            >
+                                Quiet:
+                            </sp-field-label>
+                            <sp-picker
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                quiet
+                                size="l"
+                                id="picker-invalid-quiet-l"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                size="l"
+                                for="picker-disabled-invalid-quiet-l"
+                            >
+                                Quiet:
+                            </sp-field-label>
+                            <sp-picker
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                quiet
+                                size="l"
+                                disabled
+                                id="picker-disabled-invalid-quiet-l"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                    </sp-field-group>
+                </div>
+
+                <div class="size-div" style="display: block; margin-left: 10px">
+                    <div id="variantLabel">Extra Large</div>
+                    <sp-field-group>
+                        <div class="variantDiv">
+                            <sp-field-label for="picker-xl" size="xl">
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-xl"
+                                size="xl"
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label for="picker-disabled-xl" size="xl">
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-disabled-xl"
+                                size="xl"
+                                disabled
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label for="picker-xl-quiet" size="xl">
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-xl-quiet"
+                                quiet
+                                size="xl"
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                for="picker-disabled-xl-quiet"
+                                size="xl"
+                            >
+                                Selection type:
+                            </sp-field-label>
+                            <sp-picker
+                                id="picker-disabled-xl-quiet"
+                                quiet
+                                size="xl"
+                                disabled
+                                label="Selection type"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label size="xl" for="picker-invalid-xl">
+                                Standard:
+                            </sp-field-label>
+                            <sp-picker
+                                size="xl"
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                id="picker-invalid-xl"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                size="xl"
+                                for="picker-disabled-invalid-xl"
+                            >
+                                Standard:
+                            </sp-field-label>
+                            <sp-picker
+                                size="xl"
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                disabled
+                                id="picker-disabled-invalid-xl"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                size="xl"
+                                for="picker-invalid-quiet-xl"
+                            >
+                                Quiet:
+                            </sp-field-label>
+                            <sp-picker
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                quiet
+                                size="xl"
+                                id="picker-invalid-quiet-xl"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                        <div class="variantDiv">
+                            <sp-field-label
+                                size="xl"
+                                for="picker-disabled-invalid-quiet-xl"
+                            >
+                                Quiet:
+                            </sp-field-label>
+                            <sp-picker
+                                label="Select a Country with a very long label, too long in fact"
+                                invalid
+                                quiet
+                                disabled
+                                size="xl"
+                                id="picker-disabled-invalid-quiet-xl"
+                            >
+                                <sp-menu-item>Deselect</sp-menu-item>
+                                <sp-menu-item>Select inverse</sp-menu-item>
+                                <sp-menu-item>Feather...</sp-menu-item>
+                                <sp-menu-item>Select and mask...</sp-menu-item>
+                                <sp-menu-divider></sp-menu-divider>
+                                <sp-menu-item>Save selection</sp-menu-item>
+                                <sp-menu-item disabled>
+                                    Make work path
+                                </sp-menu-item>
+                            </sp-picker>
+                        </div>
+                    </sp-field-group>
+                </div>
+            </div>
+
+            <div id="variantLabel">icos</div>
+            <div class="demo-example" style="display: flex">
+                <sp-field-label for="picker-icons">
+                    Choose an action...
+                </sp-field-label>
+                <sp-picker
+                    label="What would you like to do?"
+                    value="item-2"
+                    id="picker-icons"
+                >
+                    <sp-menu-item>
+                        <sp-icon-save-floppy slot="icon"></sp-icon-save-floppy>
+                        Save
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        <sp-icon-stopwatch slot="icon"></sp-icon-stopwatch>
+                        Finish
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        <sp-icon-user-activity
+                            slot="icon"
+                        ></sp-icon-user-activity>
+                        Review
+                    </sp-menu-item>
+                </sp-picker>
+            </div>
+
+            <div class="demo-example" style="display: flex">
+                <sp-field-label for="picker-icons-only">
+                    Choose an action...
+                </sp-field-label>
+                <sp-picker
+                    label="What would you like to do?"
+                    value="item-2"
+                    id="picker-icons-only"
+                >
+                    <sp-menu-item value="item-1">
+                        <sp-icon-save-floppy
+                            slot="icon"
+                            label="Save"
+                        ></sp-icon-save-floppy>
+                    </sp-menu-item>
+                    <sp-menu-item value="item-2">
+                        <sp-icon-stopwatch
+                            slot="icon"
+                            label="Finish"
+                        ></sp-icon-stopwatch>
+                    </sp-menu-item>
+                    <sp-menu-item value="item-3">
+                        <sp-icon-user-activity
+                            slot="icon"
+                            label="Review"
+                        ></sp-icon-user-activity>
+                    </sp-menu-item>
+                </sp-picker>
+            </div>
+
+            <div class="demo-example" style="display: flex">
+                <sp-field-label for="picker-icons-value">
+                    Choose an action...
+                </sp-field-label>
+                <sp-picker
+                    label="What would you like to do?"
+                    value="item-2"
+                    id="picker-icons-value"
+                    icons="only"
+                >
+                    <sp-menu-item>
+                        <sp-icon-save-floppy slot="icon"></sp-icon-save-floppy>
+                        Save
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        <sp-icon-stopwatch slot="icon"></sp-icon-stopwatch>
+                        Finish
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        <sp-icon-user-activity
+                            slot="icon"
+                        ></sp-icon-user-activity>
+                        Review
+                    </sp-menu-item>
+                </sp-picker>
+            </div>
+
+            <div class="demo-example" style="display: flex">
+                <sp-field-label for="picker-icons-none">
+                    Choose an action...
+                </sp-field-label>
+                <sp-picker
+                    label="What would you like to do?"
+                    value="item-2"
+                    id="picker-icons-none"
+                    icons="none"
+                >
+                    <sp-menu-item>
+                        <sp-icon-save-floppy slot="icon"></sp-icon-save-floppy>
+                        Save
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        <sp-icon-stopwatch slot="icon"></sp-icon-stopwatch>
+                        Finish
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        <sp-icon-user-activity
+                            slot="icon"
+                        ></sp-icon-user-activity>
+                        Review
+                    </sp-menu-item>
+                </sp-picker>
+            </div>
+
+            <div id="variantLabel">matching value</div>
+            <div class="demo-example" style="display: flex">
+                <sp-field-label for="picker-value">
+                    Selection type:
+                </sp-field-label>
+                <sp-picker
+                    label="Select a Country with a very long label, too long in fact"
+                    value="item-2"
+                    id="picker-value"
+                >
+                    <sp-menu-item value="item-1">Deselect</sp-menu-item>
+                    <sp-menu-item value="item-2">Select inverse</sp-menu-item>
+                    <sp-menu-item value="item-3">Feather...</sp-menu-item>
+                    <sp-menu-item value="item-4">
+                        Select and mask...
+                    </sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item value="item-5">Save selection</sp-menu-item>
+                    <sp-menu-item disabled value="item-6">
+                        Make work path
+                    </sp-menu-item>
+                </sp-picker>
+            </div>
+
+            <div id="variantLabel">matching itemText</div>
+            <div class="demo-example" style="display: flex">
+                <sp-field-label for="picker-item-text">
+                    Selection type:
+                </sp-field-label>
+                <sp-picker
+                    label="Select a Country with a very long label, too long in fact"
+                    value="Feather..."
+                    id="picker-item-text"
+                >
+                    <sp-menu-item>Deselect</sp-menu-item>
+                    <sp-menu-item>Select inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and mask...</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Save selection</sp-menu-item>
+                    <sp-menu-item>Make work path</sp-menu-item>
+                </sp-picker>
+            </div>
+
+            <div id="variantLabel">side label</div>
+            <div class="demo-example" style="display: flex">
+                <sp-field-group>
+                    <div class="variantDiv">
+                        <sp-field-label
+                            side-aligned="start"
+                            for="picker-sideLabel"
+                        >
+                            Standard:
+                        </sp-field-label>
+                        <sp-picker
+                            label="Select a Country with a very long label, too long in fact"
+                            id="picker-sideLabel"
+                        >
+                            <sp-menu-item>Deselect</sp-menu-item>
+                            <sp-menu-item>Select inverse</sp-menu-item>
+                            <sp-menu-item>Feather...</sp-menu-item>
+                            <sp-menu-item>Select and mask...</sp-menu-item>
+                            <sp-menu-divider></sp-menu-divider>
+                            <sp-menu-item>Save selection</sp-menu-item>
+                            <sp-menu-item disabled>Make work path</sp-menu-item>
+                        </sp-picker>
+                    </div>
+                    <div>
+                        <sp-field-label
+                            side-aligned="start"
+                            for="picker-sideLabel-quiet"
+                        >
+                            Quiet:
+                        </sp-field-label>
+                        <sp-picker
+                            label="Select a Country with a very long label, too long in fact"
+                            quiet
+                            id="picker-sideLabel-quiet"
+                        >
+                            <sp-menu-item>Deselect</sp-menu-item>
+                            <sp-menu-item>Select inverse</sp-menu-item>
+                            <sp-menu-item>Feather...</sp-menu-item>
+                            <sp-menu-item>Select and mask...</sp-menu-item>
+                            <sp-menu-divider></sp-menu-divider>
+                            <sp-menu-item>Save selection</sp-menu-item>
+                            <sp-menu-item disabled>Make work path</sp-menu-item>
+                        </sp-picker>
+                    </div>
+                </sp-field-group>
+            </div>
+        </div>
+        <input type="text" style="width: 2px" />
+        <div id="right">
+            <div id="subtitle">my-picker</div>
+            <my-picker label="Selection type">
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save selection</sp-menu-item>
+                <sp-menu-item disabled>Make work path</sp-menu-item>
+            </my-picker>
+        </div>
+    </div>
+
+    <div id="config">
+        <div style="display: inline-flex">
+            <sp-field-label size="l" side-aligned="end" for="picker-sizes">
+                Sizes
+            </sp-field-label>
+            <select id="picker-sizes">
+                <option value="s">Small</option>
+                <option selected value="m" selected>Medium</option>
+                <option value="l">Large</option>
+                <option value="xl">Extra Large</option>
+            </select>
+        </div>
+
+        <div style="display: flex; flex-direction: column">
+            <sp-checkbox id="disabled">Disabled</sp-checkbox>
+            <sp-checkbox id="invalid">Invalid</sp-checkbox>
+            <sp-checkbox id="quiet">Quiet</sp-checkbox>
+            <sp-checkbox id="readonly">Readonly</sp-checkbox>
+        </div>
+    </div>
+</div>

--- a/projects/swc-starter-webpack/src/extended_swc_samples/my-action-menu.js
+++ b/projects/swc-starter-webpack/src/extended_swc_samples/my-action-menu.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,5 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './aliases.js';
-export * from './MatchMediaController.js';
+import { css } from 'lit';
+import { ActionMenu } from '@spectrum-web-components/action-menu';
+
+class MyActionMenu extends ActionMenu {
+    static styles = [ActionMenu.styles, css``];
+}
+
+customElements.define('my-action-menu', MyActionMenu);

--- a/projects/swc-starter-webpack/src/extended_swc_samples/my-picker.js
+++ b/projects/swc-starter-webpack/src/extended_swc_samples/my-picker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,5 +10,18 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './aliases.js';
-export * from './MatchMediaController.js';
+import { css } from 'lit';
+import { Picker } from '@spectrum-web-components/picker';
+
+class MyPicker extends Picker {
+    static styles = [
+        Picker.styles,
+        css`
+            #button {
+                background: aquamarine;
+            }
+        `,
+    ];
+}
+
+customElements.define('my-picker', MyPicker);

--- a/projects/swc-starter-webpack/src/index.html
+++ b/projects/swc-starter-webpack/src/index.html
@@ -339,6 +339,18 @@ governing permissions and limitations under the License.
                     >
                         sp-swatch
                     </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-picker')"
+                    >
+                        sp-picker
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-action-menu')"
+                    >
+                        sp-action-menu
+                    </button>
                 </div>
             </div>
             <div id="loging">
@@ -541,6 +553,14 @@ governing permissions and limitations under the License.
 
             <div id="sp-overlay" class="tabcontent">
                 <!--#include sp-overlay.html -->
+            </div>
+
+            <div id="sp-picker" class="tabcontent">
+                <!--#include sp-picker.html -->
+            </div>
+
+            <div id="sp-action-menu" class="tabcontent">
+                <!--#include sp-action-menu.html -->
             </div>
         </sp-theme>
     </body>

--- a/projects/swc-starter-webpack/src/index.js
+++ b/projects/swc-starter-webpack/src/index.js
@@ -63,6 +63,8 @@ import '@spectrum-web-components/table/sp-table-row.js';
 
 import '@spectrum-web-components/overlay/sp-overlay.js';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
+import '@spectrum-web-components/picker/sp-picker.js';
+import '@spectrum-web-components/action-menu/sp-action-menu.js';
 
 import '@spectrum-web-components/number-field/sp-number-field.js';
 import '@spectrum-web-components/search/sp-search.js';
@@ -87,6 +89,7 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-delete.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-save-floppy.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-stopwatch.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-user-activity.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 
 // Importing custom elements (my-*) extended from the respective Spectrum Web Components
 import './extended_swc_samples/my-banner.js';
@@ -126,3 +129,5 @@ import './extended_swc_samples/my-quick-actions.js';
 import './extended_swc_samples/my-meter.js';
 import './extended_swc_samples/my-swatch.js';
 import './extended_swc_samples/my-overlay.js';
+import './extended_swc_samples/my-picker.js';
+import './extended_swc_samples/my-action-menu.js';

--- a/projects/swc-starter-webpack/src/styles.css
+++ b/projects/swc-starter-webpack/src/styles.css
@@ -89,10 +89,16 @@ sp-action-group {
 }
 
 sp-textfield,
+sp-tabs,
 sp-tags,
+sp-split-view,
 sp-number-field,
 sp-search {
     margin-bottom: 20px;
+}
+
+sp-tabs {
+    margin-bottom: 40px;
 }
 
 sp-toast {
@@ -173,10 +179,26 @@ p {
 }
 
 .size-div {
-    margin: 5px;
+    padding: 10px;
+    background: var(--spectrum-global-color-gray-200);
     display: flex;
     flex-direction: column;
     align-items: center;
+}
+
+sp-accordion {
+    width: 100%;
+    margin: 10px;
+}
+
+.size-div > sp-field-label {
+    background-color: var(--spectrum-gray-300);
+    width: 100%;
+    padding: 10px;
+}
+
+.variantDiv {
+    padding-bottom: 20px;
 }
 
 #console {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,7 +1103,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.6.2", "@babel/runtime@^7.8.4":
   version "7.25.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.0.tgz#3af9a91c1b739c569d5d80cc917280919c544ecb"
   integrity sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==
@@ -1294,30 +1294,25 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@floating-ui/core@^1.6.0":
+"@floating-ui/core@^1.4.1":
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.7.tgz#7602367795a390ff0662efd1c7ae8ca74e75fb12"
   integrity sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==
   dependencies:
     "@floating-ui/utils" "^0.2.7"
 
-"@floating-ui/dom@^1.2.0", "@floating-ui/dom@^1.5.1":
-  version "1.6.10"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.10.tgz#b74c32f34a50336c86dcf1f1c845cf3a39e26d6f"
-  integrity sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==
+"@floating-ui/dom@1.5.1", "@floating-ui/dom@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.1.tgz#88b70defd002fe851f17b4a25efb2d3c04d7a8d7"
+  integrity sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==
   dependencies:
-    "@floating-ui/core" "^1.6.0"
-    "@floating-ui/utils" "^0.2.7"
+    "@floating-ui/core" "^1.4.1"
+    "@floating-ui/utils" "^0.1.1"
 
-"@floating-ui/utils@^0.1.1":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
-  integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
-
-"@floating-ui/utils@^0.2.7":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.7.tgz#d0ece53ce99ab5a8e37ebdfe5e32452a2bfc073e"
-  integrity sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==
+"@floating-ui/utils@0.1.1", "@floating-ui/utils@^0.1.1", "@floating-ui/utils@^0.2.7":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.1.tgz#1a5b1959a528e374e8037c4396c3e825d6cf4a83"
+  integrity sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -1348,12 +1343,12 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@internationalized/number@^3.1.0":
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/@internationalized/number/-/number-3.5.3.tgz#9fa060c1c4809f23fb3d38dd3f3d1ae4c87e95a8"
-  integrity sha512-rd1wA3ebzlp0Mehj5YTuTI50AQEx80gWFyHcQu+u91/5NgdwBecO8BH6ipPfE+lmQ9d63vpB3H9SHoIUiupllw==
+"@internationalized/number@3.1.0", "@internationalized/number@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@internationalized/number/-/number-3.1.0.tgz#441c262e43344371b17765cf691e54df5ab8726b"
+  integrity sha512-CEts+2rIB4QveKeeF6xIHdn8aLVvUt5aiarkpCZgtMyYqfqo/ZBELf2UyhvLPGpRxcF24ClCISMTP9BTVreSAg==
   dependencies:
-    "@swc/helpers" "^0.5.0"
+    "@babel/runtime" "^7.6.2"
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -1746,20 +1741,12 @@
     write-pkg "4.0.0"
     yargs "16.2.0"
 
-"@lit-labs/observers@^1.0.1":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@lit-labs/observers/-/observers-1.1.0.tgz#f121940db5f7beb44fb7239904805f398c76f356"
-  integrity sha512-+MbK+OD+Io9MvGIKY8HVB7vQVOpYxruChlw52OzHjAPl+cBPK8i+MKQ2OvH02LakRYloEc6u/Nuvz6+e8+qAbA==
+"@lit-labs/observers@2.0.0", "@lit-labs/observers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@lit-labs/observers/-/observers-2.0.0.tgz#b1ab73e43460e97b3910f6be68121bfabf14669a"
+  integrity sha512-NMbCjJEqp8V9TpTtt8HhzFVymx/WGpTD7iU+FMKSis4u3iBWwu2UYh6KChwFTEPW9xMum70r2IBnaViBINaGTA==
   dependencies:
     "@lit/reactive-element" "^1.1.0"
-
-"@lit-labs/observers@^2.0.0":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@lit-labs/observers/-/observers-2.0.3.tgz#a42a72cfa288dbd3065c7edb50313ad8d3ea6fe1"
-  integrity sha512-CeftEJ2TId9iohDJHLjUXiSBVndqjIBaALjeTt8OmgWLh2dnIzwlj4WtPCiJw15uR1s6D6wyCsw0AoJC5/9QXw==
-  dependencies:
-    "@lit/reactive-element" "^1.0.0 || ^2.0.0"
-    lit-html "^3.2.0"
 
 "@lit-labs/react@1.1.0":
   version "1.1.0"
@@ -1771,27 +1758,20 @@
   resolved "https://registry.yarnpkg.com/@lit-labs/react/-/react-1.2.1.tgz#5b421502cdf68a3639dec431318eeed2285f1c0e"
   integrity sha512-DiZdJYFU0tBbdQkfwwRSwYyI/mcWkg3sWesKRsHUd4G+NekTmmeq9fzsurvcKTNVa0comNljwtg4Hvi1ds3V+A==
 
-"@lit-labs/ssr-dom-shim@^1.0.0", "@lit-labs/ssr-dom-shim@^1.1.0", "@lit-labs/ssr-dom-shim@^1.2.0":
+"@lit-labs/ssr-dom-shim@^1.0.0", "@lit-labs/ssr-dom-shim@^1.1.0":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz#2f3a8f1d688935c704dbc89132394a41029acbb8"
   integrity sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==
 
-"@lit-labs/virtualizer@^2.0.2":
-  version "2.0.14"
-  resolved "https://registry.yarnpkg.com/@lit-labs/virtualizer/-/virtualizer-2.0.14.tgz#2b5bddc41478d75712c8963ad27b0bb8449ee309"
-  integrity sha512-lXDKPKd4QmrBWDxyJyShUcnrKAggU3BhVZpg/XU/Oz7z/BZY2kp8aGDCa2+FHQYB8Rul0bEbBJx6XrzmxMoPXg==
+"@lit-labs/virtualizer@2.0.2", "@lit-labs/virtualizer@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@lit-labs/virtualizer/-/virtualizer-2.0.2.tgz#7ba1435b3c88d95b7e922eda47508e2a255770b9"
+  integrity sha512-+E+UKTbEfQC5j7FNqN1xWBdGtzfREPbqPAGsNRiz7g2orXb2y+rBy6FmfTQ+Qcly2fjkei06xRg7f/yN/hS3zQ==
   dependencies:
-    lit "^3.2.0"
+    lit "^2.7.0"
     tslib "^2.0.3"
 
-"@lit/reactive-element@^1.0.0 || ^2.0.0", "@lit/reactive-element@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-2.0.4.tgz#8f2ed950a848016383894a26180ff06c56ae001b"
-  integrity sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==
-  dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.2.0"
-
-"@lit/reactive-element@^1.1.0", "@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.6.0":
+"@lit/reactive-element@^1.1.0", "@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.5.0":
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.6.3.tgz#25b4eece2592132845d303e091bad9b04cdcfe03"
   integrity sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==
@@ -2324,18 +2304,28 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@spectrum-web-components/action-button@^0.10.16":
-  version "0.10.16"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/action-button/-/action-button-0.10.16.tgz#7efa5fd806e15bd2d0e21a71c75d3d7780dbc8be"
-  integrity sha512-6JRJwZT+/JfzOpHVFSagjfAQ7D2S+c/hT1jp5BUyrlPbChbCTr1gtt+Ghja9SlrcUo5/pwnq6OVqFN/IwngTAg==
+"@spectrum-web-components/accordion@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/accordion/-/accordion-0.37.0.tgz#42bb56213304e30bb3868b0c11831dac4a8290c1"
+  integrity sha512-64cGyQ13i6vWNym3bP12nMirJMRY+rfrwF6p7/uYw2jtTTZ+QJTJAWxDvAi6+xQKrzdTc27v84tyWZ3i3FzrSQ==
   dependencies:
-    "@spectrum-web-components/base" "^0.7.5"
-    "@spectrum-web-components/button" "^0.20.5"
-    "@spectrum-web-components/icon" "^0.12.11"
-    "@spectrum-web-components/icons-ui" "^0.9.12"
-    "@spectrum-web-components/shared" "^0.15.7"
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/icon" "^0.37.0"
+    "@spectrum-web-components/icons-ui" "^0.37.0"
+    "@spectrum-web-components/reactive-controllers" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
 
-"@spectrum-web-components/action-button@^0.37.0", "@swc-uxp-internal/action-button@npm:@spectrum-web-components/action-button@0.37.0":
+"@spectrum-web-components/action-bar@0.37.0", "@swc-uxp-internal/action-bar@npm:@spectrum-web-components/action-bar@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/action-bar/-/action-bar-0.37.0.tgz#563138be3d69e862876ece62f2093f66d01e3498"
+  integrity sha512-tf6bNCeAdJW18VbA/KCGaSVOdumFJyrtqHThJVFidrxorGaujapKW4lO3xQ1JPoLfZ67Vc0L7Z/Ubwho6wRK0w==
+  dependencies:
+    "@spectrum-web-components/action-group" "^0.37.0"
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/button" "^0.37.0"
+    "@spectrum-web-components/popover" "^0.37.0"
+
+"@spectrum-web-components/action-button@0.37.0", "@spectrum-web-components/action-button@^0.37.0", "@spectrum-web-components/action-button@^0.39.0", "@swc-uxp-internal/action-button@npm:@spectrum-web-components/action-button@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/action-button/-/action-button-0.37.0.tgz#45a5578b60b3ddf95206f4ae4f5048f4da9faa2c"
   integrity sha512-cU/5sHpRSA823sHUH6jZccmizkTxWr/LJHTDJ4jj0LxCLh15OHfxKM+hu/vcc5fXYrAPma5Hp54xTBc/l/frDA==
@@ -2346,7 +2336,7 @@
     "@spectrum-web-components/icons-ui" "^0.37.0"
     "@spectrum-web-components/shared" "^0.37.0"
 
-"@spectrum-web-components/action-group@^0.37.0", "@swc-uxp-internal/action-group@npm:@spectrum-web-components/action-group@0.37.0":
+"@spectrum-web-components/action-group@0.37.0", "@spectrum-web-components/action-group@^0.37.0", "@swc-uxp-internal/action-group@npm:@spectrum-web-components/action-group@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/action-group/-/action-group-0.37.0.tgz#7d8586f2fd57f782ae8ae887cff042768b260d6e"
   integrity sha512-unC1SMjhWI080lfHeAMxBL1y2Vyk6fIhKdukWzqQnzMpPdogh+tvKF9kUgPLZ3rq0hFFCquT0ZZezyywvjTWZA==
@@ -2357,35 +2347,36 @@
     "@spectrum-web-components/icons-workflow" "^0.37.0"
     "@spectrum-web-components/reactive-controllers" "^0.37.0"
 
-"@spectrum-web-components/asset@^0.37.0", "@swc-uxp-internal/asset@npm:@spectrum-web-components/asset@0.37.0":
+"@spectrum-web-components/asset@0.37.0", "@spectrum-web-components/asset@^0.37.0", "@swc-uxp-internal/asset@npm:@spectrum-web-components/asset@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/asset/-/asset-0.37.0.tgz#92f17644b039f467b28f0e81cdee89b5283d1913"
   integrity sha512-nFZ4/TCHbUcNUay5NI1fLhLejtx7QJ3H+diCNsZXOvmUI+0atcNPid6j5/4CyvSd8PQooEvCgHpbHf39AM57Cg==
   dependencies:
     "@spectrum-web-components/base" "^0.37.0"
 
-"@spectrum-web-components/asset@^0.7.6":
-  version "0.7.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/asset/-/asset-0.7.9.tgz#3c92c2d6d3f9ee5db7d0e6558ab5c5a964d11cae"
-  integrity sha512-hrZfdcULmttlaJajlUZNaueFRYtpCjA6Ntswmk8MoMsWt6mDhyakkHGY0VLTeQnBP8JETB1iGLej6V9zsgefdw==
+"@spectrum-web-components/avatar@0.37.0", "@swc-uxp-internal/avatar@npm:@spectrum-web-components/avatar@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/avatar/-/avatar-0.37.0.tgz#ecd6950855313c54b96b9a5db5fb8b2e014e1fa9"
+  integrity sha512-VU9qHpdQZcZ4IlatAvehBwasXZgA3sSDv+awiN3EZqXw+DyYFD1w6cKaAgtnvMH2YsXqoZnTZc1aOGvnoz6WYQ==
   dependencies:
-    "@spectrum-web-components/base" "^0.7.5"
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
 
-"@spectrum-web-components/banner@^0.9.5-react.32+342d768c5":
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/banner/-/banner-0.9.6.tgz#224d6b64eaa5ee72c7c669f8cd62e58aaed92869"
-  integrity sha512-C1e6KOqiwVtS8pSEUh5ydtCQwVCYX16Ypk5Haw10d9p3CEQdS10xIeFIDHWrRvlI54qOnM6GoSpTHWVTiKpDEw==
+"@spectrum-web-components/banner@0.37.0", "@spectrum-web-components/banner@^0.9.5-react.32+342d768c5", "@swc-uxp-internal/banner@npm:@spectrum-web-components/banner@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/banner/-/banner-0.37.0.tgz#c7cc12049e96248e453e7694902ee69e4bcd6751"
+  integrity sha512-+aSC4vBNXY9KGfIR9HNVVUdHcLc5cgA6yI+1VtxwrXXuaylS3TQ7BNzT07R8w9REXf1YPQmGFYXPomEttTDZhw==
   dependencies:
-    "@spectrum-web-components/base" "^0.7.5"
+    "@spectrum-web-components/base" "^0.37.0"
 
-"@spectrum-web-components/base@0.37.0", "@spectrum-web-components/base@^0.37.0", "@spectrum-web-components/base@^0.7.4", "@spectrum-web-components/base@^0.7.5":
+"@spectrum-web-components/base@0.37.0", "@spectrum-web-components/base@^0.37.0", "@spectrum-web-components/base@^0.39.0", "@swc-uxp-internal/base@npm:@spectrum-web-components/base@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/base/-/base-0.37.0.tgz#d0fccbbc066c270773bcd7ece827128098edb897"
   integrity sha512-3JOI36CemlFzXKAuennOBZ2k99ayd6yooG8eX24z58r0nT6I+3q6jYbytBRJuj48Y7vxwxqMIKX4V118A1dmMQ==
   dependencies:
     lit "^2.5.0"
 
-"@spectrum-web-components/button-group@^0.37.0", "@swc-uxp-internal/button-group@npm:@spectrum-web-components/button-group@0.37.0":
+"@spectrum-web-components/button-group@0.37.0", "@spectrum-web-components/button-group@^0.37.0", "@swc-uxp-internal/button-group@npm:@spectrum-web-components/button-group@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/button-group/-/button-group-0.37.0.tgz#3f5c52d35eccc1d33c9799a0a3d645ccccce4f68"
   integrity sha512-GpFU7LftPsfSMifWbE5u4XKVOLCCGlotnuaBfiC+SIb/pRGMQvmysK+hzgDXHDl+KiFGimgNk8bxBpHODyE9ug==
@@ -2393,31 +2384,7 @@
     "@spectrum-web-components/base" "^0.37.0"
     "@spectrum-web-components/button" "^0.37.0"
 
-"@spectrum-web-components/button@^0.19.8-react.54+c59ca07be":
-  version "0.19.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/button/-/button-0.19.10.tgz#b6af405ae64fcdd2def7856a339c4fc29754715c"
-  integrity sha512-5uI7tL3ZRz4n6v1limKbC54D7MPQ6icwpjs+bCiVjppUbbucNSEk+Cs95wWaSQQapk23BpTL3W3OCRpYvnCohQ==
-  dependencies:
-    "@spectrum-web-components/base" "^0.7.4"
-    "@spectrum-web-components/clear-button" "^0.2.5"
-    "@spectrum-web-components/close-button" "^0.3.8"
-    "@spectrum-web-components/icon" "^0.12.7"
-    "@spectrum-web-components/icons-ui" "^0.9.7"
-    "@spectrum-web-components/shared" "^0.15.5"
-
-"@spectrum-web-components/button@^0.20.5":
-  version "0.20.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/button/-/button-0.20.5.tgz#ad77a4346be9282cf6f051754714bf5c1b51ef11"
-  integrity sha512-RRO9qnIcJIHCn+Tv5k9zSoFhxQ869pytYJXDMs/pgeedsA4qpWjoswYVQWvzpqJMvVJ24pQ27kHbMGS0aG4OzQ==
-  dependencies:
-    "@spectrum-web-components/base" "^0.7.5"
-    "@spectrum-web-components/clear-button" "^0.2.9"
-    "@spectrum-web-components/close-button" "^0.3.12"
-    "@spectrum-web-components/icon" "^0.12.11"
-    "@spectrum-web-components/icons-ui" "^0.9.12"
-    "@spectrum-web-components/shared" "^0.15.7"
-
-"@spectrum-web-components/button@^0.37.0", "@swc-uxp-internal/button@npm:@spectrum-web-components/button@0.37.0":
+"@spectrum-web-components/button@0.37.0", "@spectrum-web-components/button@^0.19.8-react.54+c59ca07be", "@spectrum-web-components/button@^0.37.0", "@swc-uxp-internal/button@npm:@spectrum-web-components/button@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/button/-/button-0.37.0.tgz#ea20f663b05f6ca8ddb56e8206c56c051c5153f6"
   integrity sha512-Cz69UtdNDqNVAMUjz2i1RjZ4LetR+bTnUvaDlj8heQHYR/ZHKdnMWaxS1DnZjlu7+osFo57XJPLyhlEEgYT1Ig==
@@ -2429,30 +2396,20 @@
     "@spectrum-web-components/icons-ui" "^0.37.0"
     "@spectrum-web-components/shared" "^0.37.0"
 
-"@spectrum-web-components/card@^0.13.3":
-  version "0.13.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/card/-/card-0.13.9.tgz#c75630544cab052513af0a1f770b901647a27697"
-  integrity sha512-va6gx6ALAyChzG4Xx/bHrq/Qdpj5JUXTViXrBLadbUTAyD9EwVs6/wDq/72OXjxz6oRoFDcIwSWAV6fzB6Q7rw==
+"@spectrum-web-components/card@0.37.0", "@spectrum-web-components/card@^0.13.3", "@swc-uxp-internal/card@npm:@spectrum-web-components/card@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/card/-/card-0.37.0.tgz#f364f18d552069714bb2af28480b8e009f789088"
+  integrity sha512-NNwdXU4O7aI4gkLA2xOSHqYc/DDMoefp0YL2PFHjkxdEMW1G0cL4G7TTvow11yWmIyrtysra8sqTikNohW8Rmw==
   dependencies:
-    "@spectrum-web-components/asset" "^0.7.6"
-    "@spectrum-web-components/base" "^0.7.4"
-    "@spectrum-web-components/checkbox" "^0.14.11"
-    "@spectrum-web-components/icons-workflow" "^0.9.9"
-    "@spectrum-web-components/quick-actions" "^0.7.6"
-    "@spectrum-web-components/shared" "^0.15.5"
-    "@spectrum-web-components/styles" "^0.23.1"
+    "@spectrum-web-components/asset" "^0.37.0"
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/checkbox" "^0.37.0"
+    "@spectrum-web-components/icons-workflow" "^0.37.0"
+    "@spectrum-web-components/quick-actions" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+    "@spectrum-web-components/styles" "^0.37.0"
 
-"@spectrum-web-components/checkbox@^0.14.11":
-  version "0.14.14"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/checkbox/-/checkbox-0.14.14.tgz#46f0f12a5c311905b4e5e1b75eb0314f26deea46"
-  integrity sha512-98C2A8yxsJe11/yA7POiG02qAknCLnVf37qnnLqPuu6AwIYT7ZaImo5Lea6gTmJDuCuTZMEMq/B3Y4gu456Orw==
-  dependencies:
-    "@spectrum-web-components/base" "^0.7.5"
-    "@spectrum-web-components/icon" "^0.12.11"
-    "@spectrum-web-components/icons-ui" "^0.9.12"
-    "@spectrum-web-components/shared" "^0.15.7"
-
-"@spectrum-web-components/checkbox@^0.37.0", "@swc-uxp-internal/checkbox@npm:@spectrum-web-components/checkbox@0.37.0":
+"@spectrum-web-components/checkbox@0.37.0", "@spectrum-web-components/checkbox@^0.37.0", "@swc-uxp-internal/checkbox@npm:@spectrum-web-components/checkbox@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/checkbox/-/checkbox-0.37.0.tgz#1d662bc779b4ce6f63565ac4551d183f20b1f247"
   integrity sha512-5DV4/aTZUkKyb6U3AHn/zxqbCeb+P1dWibp4Zjvr1FcRbMKdmY782pzRSOOXygLPkLJMKPCN4r6py32gBZY+eg==
@@ -2462,49 +2419,42 @@
     "@spectrum-web-components/icons-ui" "^0.37.0"
     "@spectrum-web-components/shared" "^0.37.0"
 
-"@spectrum-web-components/clear-button@^0.2.5", "@spectrum-web-components/clear-button@^0.2.9":
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/clear-button/-/clear-button-0.2.9.tgz#b45c19daba6b3dc37e8ef84a7a5b53a1b9e0d18c"
-  integrity sha512-S2JX0JovYVnp0e9w8IbXfyHv98IbbNd/YYSNYx7bHgWeFdty/j1ncaGxdoor0ErfeSimiTgOgy1CG3VGdacUew==
-  dependencies:
-    "@spectrum-web-components/base" "^0.7.5"
-
-"@spectrum-web-components/clear-button@^0.37.0":
+"@spectrum-web-components/clear-button@0.37.0", "@spectrum-web-components/clear-button@^0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/clear-button/-/clear-button-0.37.0.tgz#8b2efda8d93219f3db7ba9791750f124c64c6c1f"
   integrity sha512-8NGvpHogC/pWGgKnVD1ZN0t+WWtuKrW6muNRI9fPJW0rGzVTTNzsTvL/QNrGusBES8/aiT08L35ayV3QfnAU7g==
   dependencies:
     "@spectrum-web-components/base" "^0.37.0"
 
-"@spectrum-web-components/close-button@^0.3.12", "@spectrum-web-components/close-button@^0.3.8":
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/close-button/-/close-button-0.3.12.tgz#b1ba4d42018816b8139037b3db9ea8be08dacac2"
-  integrity sha512-HlU6eU2HjH7R+5fMXrITfM1FdcO7hqa9VLujXizihYzuj480rm+3ZYY8IR6gWhjri5BxgMi+kBJmeTZQVPXK0w==
-  dependencies:
-    "@spectrum-web-components/base" "^0.7.5"
-
-"@spectrum-web-components/close-button@^0.37.0":
+"@spectrum-web-components/close-button@0.37.0", "@spectrum-web-components/close-button@^0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/close-button/-/close-button-0.37.0.tgz#2094dd88c9b4380f121cb6edb79c271a79cf11d1"
   integrity sha512-sqqDyi725V3/3oy2J+IbUTlcHpZKEY7m+wXifanQ5mDOjP/8zX17DDZgSX2X7HI4IFevBSVYZxCV2MUhG5Zp1w==
   dependencies:
     "@spectrum-web-components/base" "^0.37.0"
 
-"@spectrum-web-components/divider@^0.37.0", "@swc-uxp-internal/divider@npm:@spectrum-web-components/divider@0.37.0":
+"@spectrum-web-components/dialog@0.37.0", "@swc-uxp-internal/dialog@npm:@spectrum-web-components/dialog@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/dialog/-/dialog-0.37.0.tgz#7d17e13d976afaaee6d7edaf70309d1e7a6e54b7"
+  integrity sha512-qHBWlKZF8MerMGrZgrnpsReI22X/xOyYr68+swJHP8rk29HYY+4Suv2w3tn5VnHhlnVLFsntgTBvmG/Gbw67qA==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/button" "^0.37.0"
+    "@spectrum-web-components/button-group" "^0.37.0"
+    "@spectrum-web-components/divider" "^0.37.0"
+    "@spectrum-web-components/icons-workflow" "^0.37.0"
+    "@spectrum-web-components/modal" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+    "@spectrum-web-components/underlay" "^0.37.0"
+
+"@spectrum-web-components/divider@0.37.0", "@spectrum-web-components/divider@^0.37.0", "@swc-uxp-internal/divider@npm:@spectrum-web-components/divider@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/divider/-/divider-0.37.0.tgz#d16762fc2808c2123bfa05602a531545b52f6a93"
   integrity sha512-f08h0pQ4srKw9R1fT+jKHUF3s1GfV2UPpcKrrfXFclXRRlu4AuQBO8Wo6nYUj/yYCz+hRWhlmtxL/BDKmREu9w==
   dependencies:
     "@spectrum-web-components/base" "^0.37.0"
 
-"@spectrum-web-components/divider@^0.6.9":
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/divider/-/divider-0.6.9.tgz#2c42e78e7a972ecd31397c0ebf4beaa2493f1b73"
-  integrity sha512-NHLa2fhFzCzMJsXJkHwG/W1NcfGmMLNfFDRDMtBHKs4MgxQjSmBJP3WrODcnSopUs2sZEz/xFPaM6vBSTH9Zqg==
-  dependencies:
-    "@spectrum-web-components/base" "^0.7.5"
-
-"@spectrum-web-components/field-group@^0.37.0", "@swc-uxp-internal/field-group@npm:@spectrum-web-components/field-group@0.37.0":
+"@spectrum-web-components/field-group@0.37.0", "@spectrum-web-components/field-group@^0.37.0", "@swc-uxp-internal/field-group@npm:@spectrum-web-components/field-group@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/field-group/-/field-group-0.37.0.tgz#f127bf8227faea54122adb646c2bfc2961bc9b0b"
   integrity sha512-dZu8h/As8GKaTsk1ceAg55VIQhIhucnzzag4u16R1F2dCVqBdL4TV88dK8lqgD9UUB5P7Mq4JeqlQw3XRVuCag==
@@ -2512,7 +2462,7 @@
     "@spectrum-web-components/base" "^0.37.0"
     "@spectrum-web-components/help-text" "^0.37.0"
 
-"@spectrum-web-components/field-label@^0.37.0", "@swc-uxp-internal/field-label@npm:@spectrum-web-components/field-label@0.37.0":
+"@spectrum-web-components/field-label@0.37.0", "@spectrum-web-components/field-label@^0.37.0", "@swc-uxp-internal/field-label@npm:@spectrum-web-components/field-label@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/field-label/-/field-label-0.37.0.tgz#e9c30ebde9201f0dd994079474bff11964365f87"
   integrity sha512-QTk0IwONj1P8jnsIwr3xyxkNs2fMHBs2nNoHMrmEiW1/6a5TIjIIntmeOj1BUcP2wRbUB5CD3mnh44OWSbmbHQ==
@@ -2523,7 +2473,7 @@
     "@spectrum-web-components/reactive-controllers" "^0.37.0"
     "@spectrum-web-components/shared" "^0.37.0"
 
-"@spectrum-web-components/help-text@^0.37.0", "@swc-uxp-internal/help-text@npm:@spectrum-web-components/help-text@0.37.0":
+"@spectrum-web-components/help-text@0.37.0", "@spectrum-web-components/help-text@^0.37.0", "@swc-uxp-internal/help-text@npm:@spectrum-web-components/help-text@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/help-text/-/help-text-0.37.0.tgz#fc8e792ec46bac9c878c196bda1f8cda45c26ead"
   integrity sha512-MsBD9I/mVOKRrnTqFxzbtmcLvgIGrA6y7kPwldKSQeFBHmm1oey2dnrlu7NK4OtWUdJJ3dQDKi/REJX35USOcw==
@@ -2531,7 +2481,7 @@
     "@spectrum-web-components/base" "^0.37.0"
     "@spectrum-web-components/icons-workflow" "^0.37.0"
 
-"@spectrum-web-components/icon@0.37.0", "@spectrum-web-components/icon@^0.12.11", "@spectrum-web-components/icon@^0.12.7", "@spectrum-web-components/icon@^0.37.0":
+"@spectrum-web-components/icon@0.37.0", "@spectrum-web-components/icon@^0.37.0", "@spectrum-web-components/icon@^0.39.0", "@swc-uxp-internal/icon@npm:@spectrum-web-components/icon@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/icon/-/icon-0.37.0.tgz#b955d01b096308c9b6563d6fd1d6082a84862ea9"
   integrity sha512-DZ1yOKHxNQygzIJ7u9akYComDnMmxuTzfmYxxt9sHdUXmc1NbMkCJqEaAG/LYsdb+hc4xWaDTT9SzArLKZ/btA==
@@ -2539,7 +2489,7 @@
     "@spectrum-web-components/base" "^0.37.0"
     "@spectrum-web-components/iconset" "^0.37.0"
 
-"@spectrum-web-components/icons-ui@0.37.0", "@spectrum-web-components/icons-ui@^0.37.0", "@spectrum-web-components/icons-ui@^0.9.12", "@spectrum-web-components/icons-ui@^0.9.7":
+"@spectrum-web-components/icons-ui@0.37.0", "@spectrum-web-components/icons-ui@^0.37.0", "@swc-uxp-internal/icons-ui@npm:@spectrum-web-components/icons-ui@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/icons-ui/-/icons-ui-0.37.0.tgz#919e94cadb74a4cd2d2abaa9c1bdf873903e53f1"
   integrity sha512-DmaK+NDIgYhtYW19Y4lZoGYLfnFWPBjLNcLWGTQtc41yccEmgWrJbaf9n+nP4TADVJMT5dKNgE2vHnmDABtydg==
@@ -2548,7 +2498,7 @@
     "@spectrum-web-components/icon" "^0.37.0"
     "@spectrum-web-components/iconset" "^0.37.0"
 
-"@spectrum-web-components/icons-workflow@0.37.0", "@spectrum-web-components/icons-workflow@^0.37.0", "@spectrum-web-components/icons-workflow@^0.9.4", "@spectrum-web-components/icons-workflow@^0.9.9":
+"@spectrum-web-components/icons-workflow@0.37.0", "@spectrum-web-components/icons-workflow@^0.37.0", "@spectrum-web-components/icons-workflow@^0.39.0", "@spectrum-web-components/icons-workflow@^0.9.4", "@swc-uxp-internal/icons-workflow@npm:@spectrum-web-components/icons-workflow@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/icons-workflow/-/icons-workflow-0.37.0.tgz#bf086915698fbc8948fd8ae24a0299b022139a9e"
   integrity sha512-D1Dg+ZjlqbaU/2uKYhmMtZXQMVUw9J9LevHSKSzMFL+Y++JMqRROQuzwAOFW7tttCw1w0+3kIuv2ohkeE+8fNQ==
@@ -2556,7 +2506,7 @@
     "@spectrum-web-components/base" "^0.37.0"
     "@spectrum-web-components/icon" "^0.37.0"
 
-"@spectrum-web-components/icons@0.37.0":
+"@spectrum-web-components/icons@0.37.0", "@swc-uxp-internal/icons@npm:@spectrum-web-components/icons@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/icons/-/icons-0.37.0.tgz#513261357afd9ac17b9d088764e4dc8299013d24"
   integrity sha512-OH8+I2vpE+73XQKWBUBPbR36m/RYRDkuotK7DvhgJd4TjM3q2jBq4zQCxEe4vFC/eeADdgWy2CmAiK/5wrXASw==
@@ -2564,46 +2514,74 @@
     "@spectrum-web-components/base" "^0.37.0"
     "@spectrum-web-components/iconset" "^0.37.0"
 
-"@spectrum-web-components/iconset@^0.37.0":
+"@spectrum-web-components/iconset@^0.37.0", "@swc-uxp-internal/iconset@npm:@spectrum-web-components/iconset@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/iconset/-/iconset-0.37.0.tgz#03a72d461b08197c8faebb2cfaa7abaf034441f5"
   integrity sha512-s1TBjWeQtGdGf6n+r+aG2glv77IgR0pNs0HLusGyYt6jzWFkP276fE7Neqq/2XvG9a9zvAwngffnWS3td/Gtmg==
   dependencies:
     "@spectrum-web-components/base" "^0.37.0"
 
-"@spectrum-web-components/menu@^0.16.9-react.54+c59ca07be":
-  version "0.16.17"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/menu/-/menu-0.16.17.tgz#29fc21d5647fbec8fb3392364f31ceb3d7a7fb87"
-  integrity sha512-jjHReXfBDC8wBcwFdjxi3aghvbAQpPRh78IxF12oosJCTcS09ee9+N2JKv225C2T4kxDf+BaqlnHBeJEEz6CXg==
+"@spectrum-web-components/illustrated-message@0.37.0", "@swc-uxp-internal/illustrated-message@npm:@spectrum-web-components/illustrated-message@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/illustrated-message/-/illustrated-message-0.37.0.tgz#107aea2dcd048f8c346505598c584c23a69888de"
+  integrity sha512-JUop4B2MgkQpYR6PrEifHOFNNKhVwqoBy1xS1HUKLidlOovagY1Wa769ajeXUBGoL1HLKif3O+CmWTBCwAaa5A==
   dependencies:
-    "@lit-labs/observers" "^1.0.1"
-    "@spectrum-web-components/action-button" "^0.10.16"
-    "@spectrum-web-components/base" "^0.7.5"
-    "@spectrum-web-components/divider" "^0.6.9"
-    "@spectrum-web-components/icon" "^0.12.11"
-    "@spectrum-web-components/icons-ui" "^0.9.12"
-    "@spectrum-web-components/overlay" "^0.19.5"
-    "@spectrum-web-components/shared" "^0.15.7"
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/styles" "^0.37.0"
 
-"@spectrum-web-components/modal@^0.37.0":
+"@spectrum-web-components/link@0.37.0", "@swc-uxp-internal/link@npm:@spectrum-web-components/link@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/link/-/link-0.37.0.tgz#5e78355f523366ff550012f8ad1b7b9165f1af6a"
+  integrity sha512-0LkKNrDokyuguIS40reuRudiIV4ZWxL3cr6mjdAzXhfotAxM313JN1QALBsSkzsJuwbh65EFdEFAilHo11hcdA==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+
+"@spectrum-web-components/menu@0.37.0", "@spectrum-web-components/menu@^0.16.9-react.54+c59ca07be", "@spectrum-web-components/menu@^0.37.0", "@swc-uxp-internal/menu@npm:@spectrum-web-components/menu@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/menu/-/menu-0.37.0.tgz#0c89a883af6c9038ceb5667945910a01e9c6bc13"
+  integrity sha512-WG7lqePUERK/xE6/DlyfNzbW8gjSkQPEwGSxbe8AFOWTImzQALAz0rxmGTzHOkoThvsSGErt/mC7WiXkL5IWjQ==
+  dependencies:
+    "@lit-labs/observers" "^2.0.0"
+    "@spectrum-web-components/action-button" "^0.37.0"
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/divider" "^0.37.0"
+    "@spectrum-web-components/icon" "^0.37.0"
+    "@spectrum-web-components/icons-ui" "^0.37.0"
+    "@spectrum-web-components/overlay" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+
+"@spectrum-web-components/meter@0.37.0", "@swc-uxp-internal/meter@npm:@spectrum-web-components/meter@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/meter/-/meter-0.37.0.tgz#c27e01925185cef809c9f09e26129dd87eb8198d"
+  integrity sha512-MSbHCB5U7O34xYPLrKeChtx9JuCKY3IIxK6MggAqNQfsBSYk779pMP1MbOsT9e8gkgVQ0w8IQx+ttI7Ozvo7vg==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/field-label" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+
+"@spectrum-web-components/modal@0.37.0", "@spectrum-web-components/modal@^0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/modal/-/modal-0.37.0.tgz#546ec9ad8f17056e77c9c7ed61ae34f56219f3e4"
   integrity sha512-GXtRZdXFHZoP3UKu5oG7TQFEOShHhxGE5p7vvN7oFPm2Yz1WtpmjH2HdBFb2mI8BmEvKax/KEG5kZCrTDQpTvg==
   dependencies:
     "@spectrum-web-components/base" "^0.37.0"
 
-"@spectrum-web-components/overlay@^0.19.5":
-  version "0.19.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/overlay/-/overlay-0.19.5.tgz#a92fe99937643665ff3002c945751325ebe83fda"
-  integrity sha512-Zb90WiQsq0bL98O7dzmdHVVzd+ohHf9RnGrEqKWXWTnisbfIv0tpik4Z+kq4l4Ri0EwK+zEPLORiIbKxz8Fqwg==
+"@spectrum-web-components/number-field@0.37.0", "@spectrum-web-components/number-field@^0.37.0", "@swc-uxp-internal/number-field@npm:@spectrum-web-components/number-field@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/number-field/-/number-field-0.37.0.tgz#b41c265b2d2a6253fe6ee2f3e45a7016c50cbf2d"
+  integrity sha512-XJZJQGyhfnm9GY5XUBshUXb3LEgzB33D8y8hY4cSnky1a9mdpeboV+HB+z2TOkeriB9ZQTaIoT8Ev/p15Tr+ew==
   dependencies:
-    "@floating-ui/dom" "^1.2.0"
-    "@spectrum-web-components/action-button" "^0.10.16"
-    "@spectrum-web-components/base" "^0.7.5"
-    "@spectrum-web-components/shared" "^0.15.7"
-    "@spectrum-web-components/theme" "^0.15.0"
+    "@internationalized/number" "^3.1.0"
+    "@spectrum-web-components/action-button" "^0.37.0"
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/icon" "^0.37.0"
+    "@spectrum-web-components/icons-ui" "^0.37.0"
+    "@spectrum-web-components/reactive-controllers" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+    "@spectrum-web-components/textfield" "^0.37.0"
 
-"@spectrum-web-components/overlay@^0.37.0", "@swc-uxp-internal/overlay@npm:@spectrum-web-components/overlay@0.37.0":
+"@spectrum-web-components/overlay@0.37.0", "@spectrum-web-components/overlay@^0.37.0", "@swc-uxp-internal/overlay@npm:@spectrum-web-components/overlay@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/overlay/-/overlay-0.37.0.tgz#6173da0c12b407c572acba15a0024d828e7dea07"
   integrity sha512-kMEXAWdHJ/RGLbR4GHAEvgb03uaKNJSakVYgqoxQ15Z8PTq669FZQZMvYGr5VftRaXpejm5n1GK+KxuK6Cy+uw==
@@ -2616,7 +2594,33 @@
     "@spectrum-web-components/shared" "^0.37.0"
     "@spectrum-web-components/theme" "^0.37.0"
 
-"@spectrum-web-components/popover@^0.37.0", "@swc-uxp-internal/popover@npm:@spectrum-web-components/popover@0.37.0":
+"@spectrum-web-components/picker-button@0.37.0", "@swc-uxp-internal/picker-button@npm:@spectrum-web-components/picker-button@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/picker-button/-/picker-button-0.37.0.tgz#d8f097a81f83251b193c39889ede93270276f9f6"
+  integrity sha512-82d8nELxO+JNPPiP4t4v3pYe+afYVZyhnBxT/SPLOp+o5ZsjiCMO0zJ/ZBtbvItQcJBrquDp6R5vgHYyImL+4w==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/button" "^0.37.0"
+    "@spectrum-web-components/icons-ui" "^0.37.0"
+
+"@spectrum-web-components/picker@0.37.0", "@spectrum-web-components/picker@^0.39.0", "@swc-uxp-internal/picker@npm:@spectrum-web-components/picker@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/picker/-/picker-0.37.0.tgz#89d7cf55836a379377c80866b38a67b4ab2566ae"
+  integrity sha512-9PEysOL7auFrlwFRkZWYb+OI2yTAZ+GM2mvEqkHfONU98g0aZO6oyjtg69RUNH9VUveqUfoEEBiZ0ihyuAL3cA==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/button" "^0.37.0"
+    "@spectrum-web-components/icon" "^0.37.0"
+    "@spectrum-web-components/icons-ui" "^0.37.0"
+    "@spectrum-web-components/icons-workflow" "^0.37.0"
+    "@spectrum-web-components/menu" "^0.37.0"
+    "@spectrum-web-components/overlay" "^0.37.0"
+    "@spectrum-web-components/popover" "^0.37.0"
+    "@spectrum-web-components/reactive-controllers" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+    "@spectrum-web-components/tray" "^0.37.0"
+
+"@spectrum-web-components/popover@0.37.0", "@spectrum-web-components/popover@^0.37.0", "@swc-uxp-internal/popover@npm:@spectrum-web-components/popover@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/popover/-/popover-0.37.0.tgz#0a37d0886994f9b24e70a6d6ff6da543a775a324"
   integrity sha512-UilQj4W2HgDMopON2RG7wEYxnGViAWBJYFaTuO7dCLgEHuQMbIN6h30JvSwfz5Z0Vr/eJgSd3I7xj0K9Bl2c6Q==
@@ -2624,28 +2628,58 @@
     "@spectrum-web-components/base" "^0.37.0"
     "@spectrum-web-components/overlay" "^0.37.0"
 
-"@spectrum-web-components/quick-actions@^0.37.0", "@swc-uxp-internal/quick-actions@npm:@spectrum-web-components/quick-actions@0.37.0":
+"@spectrum-web-components/progress-bar@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/progress-bar/-/progress-bar-0.37.0.tgz#adf82bdafa73a668c8b92721f5f626510e6efa71"
+  integrity sha512-DPDUnwT05nhCiKloupnfuzffhf+n+xrsB6NwOmJVv9Z5lNFURYKCSaXgfm/Xi8yOs4OubjAyZzHxgRURVwG66A==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/field-label" "^0.37.0"
+
+"@spectrum-web-components/progress-circle@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/progress-circle/-/progress-circle-0.37.0.tgz#11fdad6d9b51d5266adad93e220fcb09fca44b4e"
+  integrity sha512-OjabwypclIBqjUwwiWDztjy4QRV1guIojhmdv3HaCEbueX0zhv9y9XqYZn3dxKnDubSkNfT4FrYHJXaMsKrovQ==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+
+"@spectrum-web-components/quick-actions@0.37.0", "@spectrum-web-components/quick-actions@^0.37.0", "@swc-uxp-internal/quick-actions@npm:@spectrum-web-components/quick-actions@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/quick-actions/-/quick-actions-0.37.0.tgz#fdf6c4d875fa86e45e69a0b9f86907445610a6cd"
   integrity sha512-h9KRwowJ4AQh6UpDcC+iuijm1wPxf/ZhmQgwH4CeYXXl2HU9NuW67QwVkVz7axjNdY5dDh6I2bdwFD/IcZW/ug==
   dependencies:
     "@spectrum-web-components/base" "^0.37.0"
 
-"@spectrum-web-components/quick-actions@^0.7.6":
-  version "0.7.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/quick-actions/-/quick-actions-0.7.9.tgz#2fda8034d1505dc32dfac69161b478418cc89688"
-  integrity sha512-0MagjlOFgJopRxdWyKiQdMLu0GCs6jW77qjs1tp6LbcFuYuVJMqAfwFpKu//Fn2VpunDQi0kjOv/3ZXnkDoxbA==
+"@spectrum-web-components/radio@0.37.0", "@swc-uxp-internal/radio@npm:@spectrum-web-components/radio@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/radio/-/radio-0.37.0.tgz#a210fce0f4097b87d82becf3ae3ebd936eb5b768"
+  integrity sha512-Rg8vXQKcOc+0S+z+Y2MiIHCQ9h9rkJuESc4ihH88UTJyqnpm7Ejy40HIbNl6zVzN5LgT1u6wovyA2ks4Jpamng==
   dependencies:
-    "@spectrum-web-components/base" "^0.7.5"
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/field-group" "^0.37.0"
+    "@spectrum-web-components/help-text" "^0.37.0"
+    "@spectrum-web-components/reactive-controllers" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
 
-"@spectrum-web-components/reactive-controllers@0.37.0", "@spectrum-web-components/reactive-controllers@^0.37.0":
+"@spectrum-web-components/reactive-controllers@0.37.0", "@spectrum-web-components/reactive-controllers@^0.37.0", "@swc-uxp-internal/reactive-controllers@npm:@spectrum-web-components/reactive-controllers@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/reactive-controllers/-/reactive-controllers-0.37.0.tgz#70117433495758217a83105f5bbd0bfb53ca58b1"
   integrity sha512-1wnWLt88iyTPrElxZqPpyWWzScSkXY3zxi+QxIV0cFGmhRlPsH+XXqs/kGkfzRyNtE4s2AWuRZ2wtbcao6MzJQ==
   dependencies:
     lit "^2.5.0"
 
-"@spectrum-web-components/shared@0.37.0", "@spectrum-web-components/shared@^0.15.5", "@spectrum-web-components/shared@^0.15.7", "@spectrum-web-components/shared@^0.37.0":
+"@spectrum-web-components/search@0.37.0", "@swc-uxp-internal/search@npm:@spectrum-web-components/search@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/search/-/search-0.37.0.tgz#b98e7cce3e43cba10cd2377acd0e39d4950512a4"
+  integrity sha512-9ithHfHhMTC4SpVC04XRDP8SEJwI2aEJRbbpjODNJcpUruclweutsektMvh4Jm3Qk3+95C5QE8fZHBIfQ5Quhw==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/button" "^0.37.0"
+    "@spectrum-web-components/icon" "^0.37.0"
+    "@spectrum-web-components/icons-workflow" "^0.37.0"
+    "@spectrum-web-components/textfield" "^0.37.0"
+
+"@spectrum-web-components/shared@0.37.0", "@spectrum-web-components/shared@^0.37.0", "@spectrum-web-components/shared@^0.39.0", "@swc-uxp-internal/shared@npm:@spectrum-web-components/shared@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/shared/-/shared-0.37.0.tgz#c30ed716c7c72614f6e19254c038f6bf4f2188ae"
   integrity sha512-i2yJ1tpQxUffP0xcx9QfusxKlRS3eOBZXjCnxhiicHIIlQtK+mPENbUTe2mRmVLT3WPwIt6mNzoO8w/p5h0Pxw==
@@ -2654,14 +2688,86 @@
     "@spectrum-web-components/base" "^0.37.0"
     focus-visible "^5.1.0"
 
-"@spectrum-web-components/styles@0.37.0", "@spectrum-web-components/styles@^0.23.1", "@spectrum-web-components/styles@^0.37.0":
+"@spectrum-web-components/sidenav@0.37.0", "@swc-uxp-internal/sidenav@npm:@spectrum-web-components/sidenav@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/sidenav/-/sidenav-0.37.0.tgz#fe02e1685e955dee46259e628fd85e6c9436993c"
+  integrity sha512-QnlXkIoLrwhxK99QSRAXJhQMK+Uy3fVFD0ZAFQsqxtCyze32Z50dGQQuHMvp4uCqA1XkOWlVBIJ2PcC718OYZg==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/reactive-controllers" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+
+"@spectrum-web-components/slider@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/slider/-/slider-0.37.0.tgz#bcb9fe706991c6fbd7f0260c6764b2fc3ede6712"
+  integrity sha512-/tc+ubracSbCgbZiR15lYibP52Dg+n7OmroSrI92rkqYhFspecNlmkjV+M6JdbTonYGyK4a+/Ilab1GCJYAwKw==
+  dependencies:
+    "@internationalized/number" "^3.1.0"
+    "@lit-labs/observers" "^2.0.0"
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/field-label" "^0.37.0"
+    "@spectrum-web-components/number-field" "^0.37.0"
+    "@spectrum-web-components/reactive-controllers" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+    "@spectrum-web-components/theme" "^0.37.0"
+
+"@spectrum-web-components/split-view@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/split-view/-/split-view-0.37.0.tgz#1c89f3dccae414bc2159ad107ce6185f3d213466"
+  integrity sha512-FRlwZpbARJlFS/wqY24ovf6kwavXqZGtHC21CJbw0zWXT4vUAUhbl3dxU8/L4iYk/7YvcdpLUbBbm7Gv8Q38bA==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+
+"@spectrum-web-components/styles@0.37.0", "@spectrum-web-components/styles@^0.37.0", "@swc-uxp-internal/styles@npm:@spectrum-web-components/styles@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/styles/-/styles-0.37.0.tgz#e14b754cd9ebffe780e327f9f8d96832f24da438"
   integrity sha512-OGG7KSoKG7Ut/idWHUicNBQdk6Wsi/ZZASj5+UgjMGv8qivZ2XOgqms+Zg4mamnYH2aE80CG/GMxKZ3VB/iAPg==
   dependencies:
     "@spectrum-web-components/base" "^0.37.0"
 
-"@spectrum-web-components/textfield@^0.37.0", "@swc-uxp-internal/textfield@npm:@spectrum-web-components/textfield@0.37.0":
+"@spectrum-web-components/switch@0.37.0", "@swc-uxp-internal/switch@npm:@spectrum-web-components/switch@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/switch/-/switch-0.37.0.tgz#2e2da7c2f57379fddf5ae0d7f8bd6054d6a89381"
+  integrity sha512-cnGA+BvsMDJYNEVAT0nxd2UrNZ/6wzv951hIwVgUe09GDKmEWicxkZHBd8P3CojG7SAh8H4ENFfsrhbsKBvlcg==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/checkbox" "^0.37.0"
+
+"@spectrum-web-components/table@0.37.0", "@swc-uxp-internal/table@npm:@spectrum-web-components/table@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/table/-/table-0.37.0.tgz#dd0424e394799e1c19579eb1c73442fe5f27de40"
+  integrity sha512-9tmkU7Li2f381TFS82KdW7lXvi4nzQeDCcyW1FgK1GW0/QkvbN/Pvtr47a0lKXROvhHUKIReMWjFEkGv1HGyOw==
+  dependencies:
+    "@lit-labs/observers" "^2.0.0"
+    "@lit-labs/virtualizer" "^2.0.2"
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/checkbox" "^0.37.0"
+    "@spectrum-web-components/icon" "^0.37.0"
+    "@spectrum-web-components/icons-ui" "^0.37.0"
+
+"@spectrum-web-components/tabs@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/tabs/-/tabs-0.37.0.tgz#643a3905e04c0a090880fe728a543a92087df460"
+  integrity sha512-bLIAZ6MX/4e+L2NpIxfGy2DsUrBoWEC2vLoTjNgdgGyCF0BeGlAU6QZoOM/h61PJdNI9d9ksczkxQj3Io7wFVA==
+  dependencies:
+    "@lit-labs/observers" "^2.0.0"
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/icon" "^0.37.0"
+    "@spectrum-web-components/icons-ui" "^0.37.0"
+    "@spectrum-web-components/reactive-controllers" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+
+"@spectrum-web-components/tags@0.37.0", "@swc-uxp-internal/tags@npm:@spectrum-web-components/tags@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/tags/-/tags-0.37.0.tgz#de11d1adf5ed7d9d6425269a459496efa2bd4784"
+  integrity sha512-CdVZHdsB+7UZ23oVWzGojnPZYhEy9TKoGanCPmncEAAPBN+2Lcjry9UzcEjfhNd0SjtoEv5cD4vMThdDpv+QBg==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/button" "^0.37.0"
+    "@spectrum-web-components/reactive-controllers" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+
+"@spectrum-web-components/textfield@0.37.0", "@spectrum-web-components/textfield@^0.37.0", "@swc-uxp-internal/textfield@npm:@spectrum-web-components/textfield@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/textfield/-/textfield-0.37.0.tgz#f35101d1967c05fcdd39fadcbbf3eb60ca2fc823"
   integrity sha512-pDhBXQth3w3OaxXGe9tMzEHvHFoJjmf2SQzOnrPPldRYx+JOEX6/fhBGel4EVXjl81oIpR9BRGAQEOFvtIWmLg==
@@ -2673,7 +2779,7 @@
     "@spectrum-web-components/icons-workflow" "^0.37.0"
     "@spectrum-web-components/shared" "^0.37.0"
 
-"@spectrum-web-components/theme@0.37.0", "@spectrum-web-components/theme@^0.14.7", "@spectrum-web-components/theme@^0.15.0", "@spectrum-web-components/theme@^0.37.0":
+"@spectrum-web-components/theme@0.37.0", "@spectrum-web-components/theme@^0.14.7", "@spectrum-web-components/theme@^0.37.0", "@swc-uxp-internal/theme@npm:@spectrum-web-components/theme@0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/theme/-/theme-0.37.0.tgz#6e119ffd92a8572e9ad0a215630cc0d004d95651"
   integrity sha512-xfKnzwWmjD6zN1T7Jo+3yLRdjh7qx8CX2FCL/PrUu8sE2Jo4cO3/vKYLAt27bbeHF5+zxKx2hOZdPOgEpZG9Hg==
@@ -2681,7 +2787,37 @@
     "@spectrum-web-components/base" "^0.37.0"
     "@spectrum-web-components/styles" "^0.37.0"
 
-"@spectrum-web-components/underlay@^0.37.0":
+"@spectrum-web-components/toast@0.37.0", "@swc-uxp-internal/toast@npm:@spectrum-web-components/toast@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/toast/-/toast-0.37.0.tgz#cba5ca06ebe135080b5a56e0a7f919989dfeb851"
+  integrity sha512-CgAh9321jyQytvVwAYp8Tpz6Cltgfj02/OcecCSlfcaoLqF2S/23/2aNgSYjbEuQ8xgcD63oeXIHrRpMxBceyw==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/button" "^0.37.0"
+    "@spectrum-web-components/icon" "^0.37.0"
+    "@spectrum-web-components/icons-workflow" "^0.37.0"
+
+"@spectrum-web-components/tooltip@0.37.0", "@swc-uxp-internal/tooltip@npm:@spectrum-web-components/tooltip@0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/tooltip/-/tooltip-0.37.0.tgz#06dd1d3657d39e103d645e4e19a87458980beeef"
+  integrity sha512-xW48gNYZciP3mhevKEzK6hVxIm/nLgj+ci4EMlzP5AwU5cQGNne5O2Y3OIbUOZHO3/ROhJxG4aLx3m3XROYzwQ==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/overlay" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+
+"@spectrum-web-components/tray@^0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/tray/-/tray-0.37.0.tgz#90c5ccc5b526b9458bf45eec2d3aa5bdbf8cffa1"
+  integrity sha512-vYjGeIYaVWQ0+6hZMQy25qqB+AjQZllEkpO/ua9nGXSvo/wbb43H6duSwVhmT2hkyqLy0sBw7Yt2LFgPYiSySQ==
+  dependencies:
+    "@spectrum-web-components/base" "^0.37.0"
+    "@spectrum-web-components/modal" "^0.37.0"
+    "@spectrum-web-components/reactive-controllers" "^0.37.0"
+    "@spectrum-web-components/shared" "^0.37.0"
+    "@spectrum-web-components/underlay" "^0.37.0"
+
+"@spectrum-web-components/underlay@0.37.0", "@spectrum-web-components/underlay@^0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@spectrum-web-components/underlay/-/underlay-0.37.0.tgz#87d0acdc9032aea31f30030b4549db57017688a9"
   integrity sha512-H3a3HmxrqGY6+N9nQwiapxXVLEIJoQ87naoXKy7ZnEmRyUnPcLjBaoXvLZKKXEDosaYxE3Mm6dnfjyKpk5PM1Q==
@@ -2849,150 +2985,17 @@
     "@lit-labs/react" "^1.1.0"
     "@spectrum-web-components/theme" "^0.14.7"
 
-"@swc-uxp-internal/action-bar@npm:@spectrum-web-components/action-bar@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/action-bar/-/action-bar-0.37.0.tgz#563138be3d69e862876ece62f2093f66d01e3498"
-  integrity sha512-tf6bNCeAdJW18VbA/KCGaSVOdumFJyrtqHThJVFidrxorGaujapKW4lO3xQ1JPoLfZ67Vc0L7Z/Ubwho6wRK0w==
+"@swc-uxp-internal/action-menu@npm:@spectrum-web-components/action-menu@0.39.0":
+  version "0.39.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/action-menu/-/action-menu-0.39.0.tgz#782e4474d6b00719ad8900af04ad86cfb824f8b3"
+  integrity sha512-Y+/apOWLSqupcvSkVsBSmWV18BY35PFYLjzB7uBBWTkAdU+jhHIDb6elF6rAeXRnZGS9zsdNHPyrG9ZO8O6JUA==
   dependencies:
-    "@spectrum-web-components/action-group" "^0.37.0"
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/button" "^0.37.0"
-    "@spectrum-web-components/popover" "^0.37.0"
-
-"@swc-uxp-internal/avatar@npm:@spectrum-web-components/avatar@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/avatar/-/avatar-0.37.0.tgz#ecd6950855313c54b96b9a5db5fb8b2e014e1fa9"
-  integrity sha512-VU9qHpdQZcZ4IlatAvehBwasXZgA3sSDv+awiN3EZqXw+DyYFD1w6cKaAgtnvMH2YsXqoZnTZc1aOGvnoz6WYQ==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/shared" "^0.37.0"
-
-"@swc-uxp-internal/banner@npm:@spectrum-web-components/banner@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/banner/-/banner-0.37.0.tgz#c7cc12049e96248e453e7694902ee69e4bcd6751"
-  integrity sha512-+aSC4vBNXY9KGfIR9HNVVUdHcLc5cgA6yI+1VtxwrXXuaylS3TQ7BNzT07R8w9REXf1YPQmGFYXPomEttTDZhw==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-
-"@swc-uxp-internal/card@npm:@spectrum-web-components/card@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/card/-/card-0.37.0.tgz#f364f18d552069714bb2af28480b8e009f789088"
-  integrity sha512-NNwdXU4O7aI4gkLA2xOSHqYc/DDMoefp0YL2PFHjkxdEMW1G0cL4G7TTvow11yWmIyrtysra8sqTikNohW8Rmw==
-  dependencies:
-    "@spectrum-web-components/asset" "^0.37.0"
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/checkbox" "^0.37.0"
-    "@spectrum-web-components/icons-workflow" "^0.37.0"
-    "@spectrum-web-components/quick-actions" "^0.37.0"
-    "@spectrum-web-components/shared" "^0.37.0"
-    "@spectrum-web-components/styles" "^0.37.0"
-
-"@swc-uxp-internal/dialog@npm:@spectrum-web-components/dialog@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/dialog/-/dialog-0.37.0.tgz#7d17e13d976afaaee6d7edaf70309d1e7a6e54b7"
-  integrity sha512-qHBWlKZF8MerMGrZgrnpsReI22X/xOyYr68+swJHP8rk29HYY+4Suv2w3tn5VnHhlnVLFsntgTBvmG/Gbw67qA==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/button" "^0.37.0"
-    "@spectrum-web-components/button-group" "^0.37.0"
-    "@spectrum-web-components/divider" "^0.37.0"
-    "@spectrum-web-components/icons-workflow" "^0.37.0"
-    "@spectrum-web-components/modal" "^0.37.0"
-    "@spectrum-web-components/shared" "^0.37.0"
-    "@spectrum-web-components/underlay" "^0.37.0"
-
-"@swc-uxp-internal/illustrated-message@npm:@spectrum-web-components/illustrated-message@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/illustrated-message/-/illustrated-message-0.37.0.tgz#107aea2dcd048f8c346505598c584c23a69888de"
-  integrity sha512-JUop4B2MgkQpYR6PrEifHOFNNKhVwqoBy1xS1HUKLidlOovagY1Wa769ajeXUBGoL1HLKif3O+CmWTBCwAaa5A==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/styles" "^0.37.0"
-
-"@swc-uxp-internal/link@npm:@spectrum-web-components/link@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/link/-/link-0.37.0.tgz#5e78355f523366ff550012f8ad1b7b9165f1af6a"
-  integrity sha512-0LkKNrDokyuguIS40reuRudiIV4ZWxL3cr6mjdAzXhfotAxM313JN1QALBsSkzsJuwbh65EFdEFAilHo11hcdA==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/shared" "^0.37.0"
-
-"@swc-uxp-internal/menu@npm:@spectrum-web-components/menu@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/menu/-/menu-0.37.0.tgz#0c89a883af6c9038ceb5667945910a01e9c6bc13"
-  integrity sha512-WG7lqePUERK/xE6/DlyfNzbW8gjSkQPEwGSxbe8AFOWTImzQALAz0rxmGTzHOkoThvsSGErt/mC7WiXkL5IWjQ==
-  dependencies:
-    "@lit-labs/observers" "^2.0.0"
-    "@spectrum-web-components/action-button" "^0.37.0"
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/divider" "^0.37.0"
-    "@spectrum-web-components/icon" "^0.37.0"
-    "@spectrum-web-components/icons-ui" "^0.37.0"
-    "@spectrum-web-components/overlay" "^0.37.0"
-    "@spectrum-web-components/shared" "^0.37.0"
-
-"@swc-uxp-internal/meter@npm:@spectrum-web-components/meter@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/meter/-/meter-0.37.0.tgz#c27e01925185cef809c9f09e26129dd87eb8198d"
-  integrity sha512-MSbHCB5U7O34xYPLrKeChtx9JuCKY3IIxK6MggAqNQfsBSYk779pMP1MbOsT9e8gkgVQ0w8IQx+ttI7Ozvo7vg==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/field-label" "^0.37.0"
-    "@spectrum-web-components/shared" "^0.37.0"
-
-"@swc-uxp-internal/number-field@npm:@spectrum-web-components/number-field@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/number-field/-/number-field-0.37.0.tgz#b41c265b2d2a6253fe6ee2f3e45a7016c50cbf2d"
-  integrity sha512-XJZJQGyhfnm9GY5XUBshUXb3LEgzB33D8y8hY4cSnky1a9mdpeboV+HB+z2TOkeriB9ZQTaIoT8Ev/p15Tr+ew==
-  dependencies:
-    "@internationalized/number" "^3.1.0"
-    "@spectrum-web-components/action-button" "^0.37.0"
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/icon" "^0.37.0"
-    "@spectrum-web-components/icons-ui" "^0.37.0"
-    "@spectrum-web-components/reactive-controllers" "^0.37.0"
-    "@spectrum-web-components/shared" "^0.37.0"
-    "@spectrum-web-components/textfield" "^0.37.0"
-
-"@swc-uxp-internal/picker-button@npm:@spectrum-web-components/picker-button@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/picker-button/-/picker-button-0.37.0.tgz#d8f097a81f83251b193c39889ede93270276f9f6"
-  integrity sha512-82d8nELxO+JNPPiP4t4v3pYe+afYVZyhnBxT/SPLOp+o5ZsjiCMO0zJ/ZBtbvItQcJBrquDp6R5vgHYyImL+4w==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/button" "^0.37.0"
-    "@spectrum-web-components/icons-ui" "^0.37.0"
-
-"@swc-uxp-internal/radio@npm:@spectrum-web-components/radio@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/radio/-/radio-0.37.0.tgz#a210fce0f4097b87d82becf3ae3ebd936eb5b768"
-  integrity sha512-Rg8vXQKcOc+0S+z+Y2MiIHCQ9h9rkJuESc4ihH88UTJyqnpm7Ejy40HIbNl6zVzN5LgT1u6wovyA2ks4Jpamng==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/field-group" "^0.37.0"
-    "@spectrum-web-components/help-text" "^0.37.0"
-    "@spectrum-web-components/reactive-controllers" "^0.37.0"
-    "@spectrum-web-components/shared" "^0.37.0"
-
-"@swc-uxp-internal/search@npm:@spectrum-web-components/search@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/search/-/search-0.37.0.tgz#b98e7cce3e43cba10cd2377acd0e39d4950512a4"
-  integrity sha512-9ithHfHhMTC4SpVC04XRDP8SEJwI2aEJRbbpjODNJcpUruclweutsektMvh4Jm3Qk3+95C5QE8fZHBIfQ5Quhw==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/button" "^0.37.0"
-    "@spectrum-web-components/icon" "^0.37.0"
-    "@spectrum-web-components/icons-workflow" "^0.37.0"
-    "@spectrum-web-components/textfield" "^0.37.0"
-
-"@swc-uxp-internal/sidenav@npm:@spectrum-web-components/sidenav@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/sidenav/-/sidenav-0.37.0.tgz#fe02e1685e955dee46259e628fd85e6c9436993c"
-  integrity sha512-QnlXkIoLrwhxK99QSRAXJhQMK+Uy3fVFD0ZAFQsqxtCyze32Z50dGQQuHMvp4uCqA1XkOWlVBIJ2PcC718OYZg==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/reactive-controllers" "^0.37.0"
-    "@spectrum-web-components/shared" "^0.37.0"
+    "@spectrum-web-components/action-button" "^0.39.0"
+    "@spectrum-web-components/base" "^0.39.0"
+    "@spectrum-web-components/icon" "^0.39.0"
+    "@spectrum-web-components/icons-workflow" "^0.39.0"
+    "@spectrum-web-components/picker" "^0.39.0"
+    "@spectrum-web-components/shared" "^0.39.0"
 
 "@swc-uxp-internal/swatch@npm:@spectrum-web-components/swatch@0.37.0":
   version "0.37.0"
@@ -3005,62 +3008,6 @@
     "@spectrum-web-components/icons-ui" "^0.37.0"
     "@spectrum-web-components/reactive-controllers" "^0.37.0"
     "@spectrum-web-components/shared" "^0.37.0"
-
-"@swc-uxp-internal/switch@npm:@spectrum-web-components/switch@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/switch/-/switch-0.37.0.tgz#2e2da7c2f57379fddf5ae0d7f8bd6054d6a89381"
-  integrity sha512-cnGA+BvsMDJYNEVAT0nxd2UrNZ/6wzv951hIwVgUe09GDKmEWicxkZHBd8P3CojG7SAh8H4ENFfsrhbsKBvlcg==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/checkbox" "^0.37.0"
-
-"@swc-uxp-internal/table@npm:@spectrum-web-components/table@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/table/-/table-0.37.0.tgz#dd0424e394799e1c19579eb1c73442fe5f27de40"
-  integrity sha512-9tmkU7Li2f381TFS82KdW7lXvi4nzQeDCcyW1FgK1GW0/QkvbN/Pvtr47a0lKXROvhHUKIReMWjFEkGv1HGyOw==
-  dependencies:
-    "@lit-labs/observers" "^2.0.0"
-    "@lit-labs/virtualizer" "^2.0.2"
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/checkbox" "^0.37.0"
-    "@spectrum-web-components/icon" "^0.37.0"
-    "@spectrum-web-components/icons-ui" "^0.37.0"
-
-"@swc-uxp-internal/tags@npm:@spectrum-web-components/tags@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/tags/-/tags-0.37.0.tgz#de11d1adf5ed7d9d6425269a459496efa2bd4784"
-  integrity sha512-CdVZHdsB+7UZ23oVWzGojnPZYhEy9TKoGanCPmncEAAPBN+2Lcjry9UzcEjfhNd0SjtoEv5cD4vMThdDpv+QBg==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/button" "^0.37.0"
-    "@spectrum-web-components/reactive-controllers" "^0.37.0"
-    "@spectrum-web-components/shared" "^0.37.0"
-
-"@swc-uxp-internal/toast@npm:@spectrum-web-components/toast@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/toast/-/toast-0.37.0.tgz#cba5ca06ebe135080b5a56e0a7f919989dfeb851"
-  integrity sha512-CgAh9321jyQytvVwAYp8Tpz6Cltgfj02/OcecCSlfcaoLqF2S/23/2aNgSYjbEuQ8xgcD63oeXIHrRpMxBceyw==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/button" "^0.37.0"
-    "@spectrum-web-components/icon" "^0.37.0"
-    "@spectrum-web-components/icons-workflow" "^0.37.0"
-
-"@swc-uxp-internal/tooltip@npm:@spectrum-web-components/tooltip@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/tooltip/-/tooltip-0.37.0.tgz#06dd1d3657d39e103d645e4e19a87458980beeef"
-  integrity sha512-xW48gNYZciP3mhevKEzK6hVxIm/nLgj+ci4EMlzP5AwU5cQGNne5O2Y3OIbUOZHO3/ROhJxG4aLx3m3XROYzwQ==
-  dependencies:
-    "@spectrum-web-components/base" "^0.37.0"
-    "@spectrum-web-components/overlay" "^0.37.0"
-    "@spectrum-web-components/shared" "^0.37.0"
-
-"@swc/helpers@^0.5.0":
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.12.tgz#37aaca95284019eb5d2207101249435659709f4b"
-  integrity sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==
-  dependencies:
-    tslib "^2.4.0"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -6781,10 +6728,10 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
-focus-visible@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
-  integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
+focus-visible@5.1.0, focus-visible@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.1.0.tgz#4b9d40143b865f53eafbd93ca66672b3bf9e7b6a"
+  integrity sha512-nPer0rjtzdZ7csVIu233P2cUm/ks/4aVSI+5KUkYrYpgA7ujgC3p6J7FtFU+AIMWwnwYQOB/yeiOITxFeYIXiw==
 
 follow-redirects@^1.0.0, follow-redirects@^1.15.6:
   version "1.15.6"
@@ -9158,7 +9105,7 @@ lines-and-columns@~2.0.3:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-2.0.4.tgz#d00318855905d2660d8c0822e3f5a4715855fc42"
   integrity sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==
 
-lit-element@^3.3.0:
+lit-element@^3.2.0:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.3.3.tgz#10bc19702b96ef5416cf7a70177255bfb17b3209"
   integrity sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==
@@ -9167,46 +9114,21 @@ lit-element@^3.3.0:
     "@lit/reactive-element" "^1.3.0"
     lit-html "^2.8.0"
 
-lit-element@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-4.1.0.tgz#cea3eb25f15091e3fade07c4d917fa6aaf56ba7d"
-  integrity sha512-gSejRUQJuMQjV2Z59KAS/D4iElUhwKpIyJvZ9w+DIagIQjfJnhR20h2Q5ddpzXGS+fF0tMZ/xEYGMnKmaI/iww==
-  dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.2.0"
-    "@lit/reactive-element" "^2.0.4"
-    lit-html "^3.2.0"
-
-lit-html@^2.8.0:
+lit-html@^2.5.0, lit-html@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.8.0.tgz#96456a4bb4ee717b9a7d2f94562a16509d39bffa"
   integrity sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit-html@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-3.2.0.tgz#cb09071a8a1f5f0850873f9143f18f0260be1fda"
-  integrity sha512-pwT/HwoxqI9FggTrYVarkBKFN9MlTUpLrDHubTmW4SrkL3kkqW5gxwbxMMUnbbRHBC0WTZnYHcjDSCM559VyfA==
+lit@2.5.0, lit@^2.0.0, lit@^2.5.0, lit@^2.7.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-2.5.0.tgz#3a425d69ff8483effb2026957b86ae45de0bc51a"
+  integrity sha512-DtnUP6vR3l4Q8nRPPNBD+UxbAhwJPeky+OVbi3pdgMqm0g57xFSl1Sj64D1rIB+nVNdiVVg8YxB0hqKjvdadZA==
   dependencies:
-    "@types/trusted-types" "^2.0.2"
-
-lit@^2.0.0, lit@^2.5.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-2.8.0.tgz#4d838ae03059bf9cafa06e5c61d8acc0081e974e"
-  integrity sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==
-  dependencies:
-    "@lit/reactive-element" "^1.6.0"
-    lit-element "^3.3.0"
-    lit-html "^2.8.0"
-
-lit@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-3.2.0.tgz#2189d72bccbc335f733a67bfbbd295f015e68e05"
-  integrity sha512-s6tI33Lf6VpDu7u4YqsSX78D28bYQulM+VAzsGch4fx2H0eLZnJsUBsPWmGYSGoKDNbjtRv02rio1o+UdPVwvw==
-  dependencies:
-    "@lit/reactive-element" "^2.0.4"
-    lit-element "^4.1.0"
-    lit-html "^3.2.0"
+    "@lit/reactive-element" "^1.5.0"
+    lit-element "^3.2.0"
+    lit-html "^2.5.0"
 
 load-json-file@6.2.0:
   version "6.2.0"


### PR DESCRIPTION
Closes - 
https://jira.corp.adobe.com/browse/UXP-22719
https://jira.corp.adobe.com/browse/UXP-22720
https://jira.corp.adobe.com/browse/UXP-21368

We've overridden the `PickerBase `render method to address UXP's native button customisation limitation, where SWC's `PickerBase` code expects to add an error icon to the right end of the button. Also positioning of content inside UXP's native button is always centre aligned whereas SWC's `PickerBase` expect it to be left aligned. Considering these issue we have replaced native html `button` with a `div` and handled the subsequent code in `swc-uxp-wrappers`

Since we have overridden the `PickerBase`, have to override the `Picker` code as well in `swc-uxp-wrappers`