### PR TITLE
[UXP-22833] - Suggested mechanism to handle chunks being generated by webpack for SWC

### DIFF
--- a/projects/react-swc-starter-webpack/webpack.config.js
+++ b/projects/react-swc-starter-webpack/webpack.config.js
@@ -36,6 +36,7 @@ const copyStatics = {
 const shared = {
     output: {
         path: resolve('dist'), // the bundle output path
+        publicPath: '/', // entry to be included in webpack config, otherwise these chunks will not be referred.
         filename: 'bundle.js', // the name of the bundle
     },
     plugins: [

--- a/projects/swc-starter-webpack/webpack.config.js
+++ b/projects/swc-starter-webpack/webpack.config.js
@@ -119,6 +119,7 @@ const shared = (env) => {
         mode: ENV,
         output: {
             path: OUTPUT_PATH,
+            publicPath: '/', // entry to be included in webpack config, otherwise these chunks will not be referred.
             filename: '[name].bundle.js',
         },
         module: {


### PR DESCRIPTION
**Investigation regarding chunks being generated by Webpack for SWC**
As of now, we are seeing following chunks being generated in our test plugin and there may be even more as we onboard more new controls

- vendors-node_modules_focus-visible_dist_focus-visible_js.bundle.js
- vendors-node_modules_lit-labs_virtualizer_layouts_flow_js.bundle.js
- vendors-node_modules_spectrum-web-components_overlay_sp-overlay_dev_js.bundle.js

Webpack does it automatically to create chunks whenever it encounters dynamic imports [useful article on this](https://medium.com/@anuhosad/code-splitting-in-webpack-with-dynamic-imports-4385b3760ef8#:~:text=Importing%20files%20via%20the%20import,in%20the%20corresponding%20chunk%20file.)
For all the case of chunk encountered so far are where SWC relying on lazy loading (or dynamic imports - [refer here](https://github.com/adobe/spectrum-web-components/blob/main/tools/shared/src/focus-visible.ts#L43)). 

Also these polyfills are specified in the dependent control’s package as dev dependencies (for example focus-visible polyfill is included as [dependency in SWC’s shared component](https://github.com/adobe/spectrum-web-components/blob/main/tools/shared/package.json#L105)).
These chunks are loaded when required, and will result in anomaly in control behaviour if not included at all.

**Action on plugin developers**
**Option-1:**, To have publicPath entry to be included in webpack config, otherwise these chunks will not be referred.
`output: {
            path: OUTPUT_PATH,
            publicPath: '/',
            filename: '[name].bundle.js',
}`

**Option-2:** To use maxChunks in webpack config to avoid chunk being created, so that only main.bundle.js  gets generated.
`new webpack.optimize.LimitChunkCountPlugin({
     maxChunks: 1
})`


Both the above options might find its relevance based on the plugin usage and workflow. It should be the plugin architect decision to opt in based on the need.
