### PR TITLE
[UXP-22471] + Enhancing test-ability of number-field in test plugin

### DIFF
--- a/packages/search/src/uxp-search.css
+++ b/packages/search/src/uxp-search.css
@@ -101,4 +101,5 @@ governing permissions and limitations under the License.
             )
     );
     right: 0px;
+    opacity: 0.99;
 }

--- a/projects/swc-starter-webpack/src/attach-event-helper.js
+++ b/projects/swc-starter-webpack/src/attach-event-helper.js
@@ -165,6 +165,68 @@ function attachEvents(tabName) {
 
         eval(offsetListener);
     }
+
+    if (tabName === 'sp-number-field') {
+        const spNumberFieldSizes = `
+            const sizes = document.getElementById('number-field-sizes');
+            sizes.addEventListener("change", () => {
+                document.querySelector('#dynamic-api-test').setAttribute('size', sizes.value); 
+            });
+        `;
+        eval(spNumberFieldSizes);
+
+        const spNumberFieldDisabled = `
+            document.querySelector('#disabled').addEventListener('change', (evt) => {
+                    const checked = evt.target.checked;
+                    const numberField = document.querySelector('#dynamic-api-test');
+                    if (checked) {
+                        numberField.setAttribute("disabled", "disabled");
+                    } else {
+                        numberField.removeAttribute("disabled");
+                    }
+                });
+        `;
+        eval(spNumberFieldDisabled);
+
+        const spNumberFieldQuiet = `
+            document.querySelector('#quiet').addEventListener('change', (evt) => {
+                    const checked = evt.target.checked;
+                    const numberField = document.querySelector('#dynamic-api-test');
+                    if (checked) {
+                        numberField.setAttribute("quiet", "quiet");
+                    } else {
+                        numberField.removeAttribute("quiet");
+                    }
+                });
+        `;
+        eval(spNumberFieldQuiet);
+
+        const spNumberFieldIntermediate = `
+            document.querySelector('#indeterminate').addEventListener('change', (evt) => {
+                    const checked = evt.target.checked;
+                    const numberField = document.querySelector('#dynamic-api-test');
+                    if (checked) {
+                        numberField.setAttribute("indeterminate", "indeterminate");
+                    } else {
+                        numberField.removeAttribute("indeterminate");
+                    }
+                });
+        `;
+        eval(spNumberFieldIntermediate);
+
+        const spNumberFieldHideStepper = `
+            document.querySelector('#hide-stepper').addEventListener('change', (evt) => {
+                    const checked = evt.target.checked;
+                    const numberField = document.querySelector('#dynamic-api-test');
+                    if (checked) {
+                        numberField.setAttribute("hide-stepper", "hide-stepper");
+                    } else {
+                        numberField.removeAttribute("hide-stepper");
+                    }
+                });
+        `;
+        eval(spNumberFieldHideStepper);
+    }
 }
 
 function handleThemeColor(selectObject) {
@@ -213,16 +275,16 @@ function toggleEventListenerToSpControls(toggle = 'add') {
     ['click', 'focus', 'blur', 'input', 'change', 'keydown', 'keyup'].forEach(
         (evtName) => {
             Array.from(document.querySelectorAll('*')).forEach((control) => {
-                if (
-                    control._nodeName !== 'sp-theme' &&
-                    control._nodeName.startsWith('sp-')
-                ) {
-                    if (toggle === 'add') {
-                        control.addEventListener(evtName, logEvent);
-                    } else if (toggle === 'remove') {
-                        control.removeEventListener(evtName, logEvent);
-                    }
+                // if (
+                //     control?._nodeName !== 'sp-theme' &&
+                //     control?._nodeName?.startsWith('sp-')
+                // ) {
+                if (toggle === 'add') {
+                    control.addEventListener(evtName, logEvent);
+                } else if (toggle === 'remove') {
+                    control.removeEventListener(evtName, logEvent);
                 }
+                // }
             });
         }
     );

--- a/projects/swc-starter-webpack/src/example_usages/sp-number-field.html
+++ b/projects/swc-starter-webpack/src/example_usages/sp-number-field.html
@@ -31,6 +31,7 @@ governing permissions and limitations under the License.
                 <div class="size-div" style="display: block; margin-left: 10px">
                     <sp-field-label for="m">Medium</sp-field-label>
                     <sp-number-field
+                        id="dynamic-api-test"
                         label="Size"
                         value="1024"
                         size="m"
@@ -342,8 +343,27 @@ governing permissions and limitations under the License.
     </div>
 
     <div id="config">
-        <div style="display: inline-flex"></div>
+        <div style="display: inline-flex">
+            <sp-field-label
+                size="l"
+                side-aligned="end"
+                for="number-field-sizes"
+            >
+                Sizes
+            </sp-field-label>
+            <select id="number-field-sizes">
+                <option value="s">Small</option>
+                <option selected value="m" selected>Medium</option>
+                <option value="l">Large</option>
+                <option value="xl">Extra Large</option>
+            </select>
+        </div>
 
-        <div style="display: flex; flex-direction: column"></div>
+        <div style="display: flex; flex-direction: column">
+            <sp-checkbox id="disabled">Disabled</sp-checkbox>
+            <sp-checkbox id="quiet">Quiet</sp-checkbox>
+            <sp-checkbox id="indeterminate">Indeterminate</sp-checkbox>
+            <sp-checkbox id="hide-stepper">Hide Stepper</sp-checkbox>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Photoshop is having a bug in where "any custom search widget having a clear button not getting click event"
Logged issue in PS - https://jira.corp.adobe.com/browse/PS-140190

Workaround which is working is either having a non-transparent background or the opacity value between 0-1 on this cross button makes it clickable.