### PR TITLE
Bugs fixes + Linter fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,50 +14,50 @@ UXP doesn't _re-create_ the entire SWC repository but rather _extends_ from the 
 
 ### This approach allows us to
 
-- override the css styles to make the component work properly in UXP
-- lock the underlying spectrum web component version to be compatible with UXP, insulating UXP wrappers from frequent changes in the SWC library
+-   override the css styles to make the component work properly in UXP
+-   lock the underlying spectrum web component version to be compatible with UXP, insulating UXP wrappers from frequent changes in the SWC library
 
 ## Supported SWC components
 
-| Components                                                                                               | Supported SWC version | Unsupported variants/Known issues                                                      |
-| -------------------------------------------------------------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------- |
+| Components                                                                                                  | Supported SWC version | Unsupported variants/Known issues                                                         |
+| ----------------------------------------------------------------------------------------------------------- | --------------------- | ----------------------------------------------------------------------------------------- |
 | [Action Bar](https://opensource.adobe.com/spectrum-web-components/components/action-bar/)                   | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/action-bar#known-issues)   |
-| [Action Button](https://opensource.adobe.com/spectrum-web-components/components/action-button/)             | 0.37.0                |                                                                                        |
-| [Action Group](https://opensource.adobe.com/spectrum-web-components/components/action-group/)               | 0.37.0                |                                                                                        |
+| [Action Button](https://opensource.adobe.com/spectrum-web-components/components/action-button/)             | 0.37.0                |                                                                                           |
+| [Action Group](https://opensource.adobe.com/spectrum-web-components/components/action-group/)               | 0.37.0                |                                                                                           |
 | [Asset](https://opensource.adobe.com/spectrum-web-components/components/asset/)                             | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/asset#known-issues)        |
-| [Avatar](https://opensource.adobe.com/spectrum-web-components/components/avatar/)                           | 0.37.0                |                                                                                        |
-| [Banner](https://opensource.adobe.com/spectrum-web-components/components/banner/)                           | 0.37.0                |                                                                                        |
-| [Button](https://opensource.adobe.com/spectrum-web-components/components/button/)                           | 0.37.0                |                                                                                        |
-| [Button Group](https://opensource.adobe.com/spectrum-web-components/components/button-group/)               | 0.37.0                |                                                                                        |
+| [Avatar](https://opensource.adobe.com/spectrum-web-components/components/avatar/)                           | 0.37.0                |                                                                                           |
+| [Banner](https://opensource.adobe.com/spectrum-web-components/components/banner/)                           | 0.37.0                |                                                                                           |
+| [Button](https://opensource.adobe.com/spectrum-web-components/components/button/)                           | 0.37.0                |                                                                                           |
+| [Button Group](https://opensource.adobe.com/spectrum-web-components/components/button-group/)               | 0.37.0                |                                                                                           |
 | [Card](https://opensource.adobe.com/spectrum-web-components/components/card/)                               | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/card#known-issues)         |
 | [Checkbox](https://opensource.adobe.com/spectrum-web-components/components/checkbox/)                       | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/checkbox#known-issues)     |
-| [Dialog](https://opensource.adobe.com/spectrum-web-components/components/dialog/)                           | 0.37.0                |                                                                                        |
-| [Divider](https://opensource.adobe.com/spectrum-web-components/components/divider/)                         | 0.37.0                |                                                                                        |
-| [Field Group](https://opensource.adobe.com/spectrum-web-components/components/field-group/)                 | 0.37.0                |                                                                                        |
-| [Field Label](https://opensource.adobe.com/spectrum-web-components/components/field-label/)                 | 0.37.0                |                                                                                        |
-| [Help Text](https://opensource.adobe.com/spectrum-web-components/components/help-text/)                     | 0.37.0                |                                                                                        |
-| [Illustrated Message](https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/) | 0.37.0                |                                                                                        |
+| [Dialog](https://opensource.adobe.com/spectrum-web-components/components/dialog/)                           | 0.37.0                |                                                                                           |
+| [Divider](https://opensource.adobe.com/spectrum-web-components/components/divider/)                         | 0.37.0                |                                                                                           |
+| [Field Group](https://opensource.adobe.com/spectrum-web-components/components/field-group/)                 | 0.37.0                |                                                                                           |
+| [Field Label](https://opensource.adobe.com/spectrum-web-components/components/field-label/)                 | 0.37.0                |                                                                                           |
+| [Help Text](https://opensource.adobe.com/spectrum-web-components/components/help-text/)                     | 0.37.0                |                                                                                           |
+| [Illustrated Message](https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/) | 0.37.0                |                                                                                           |
 | [Link](https://opensource.adobe.com/spectrum-web-components/components/link/)                               | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/link#known-issues)         |
 | [Menu](https://opensource.adobe.com/spectrum-web-components/components/menu/)                               | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/menu#known-issues)         |
 | [Meter](https://opensource.adobe.com/spectrum-web-components/components/meter/)                             | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/meter#known-issues)        |
 | [Number Field](https://opensource.adobe.com/spectrum-web-components/components/number-field/)               | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/number-field#known-issues) |
 | [Overlay](https://opensource.adobe.com/spectrum-web-components/components/overlay/)                         | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/overlay#known-issues)      |
-| [Picker Button](https://opensource.adobe.com/spectrum-web-components/components/picker-button/)             | 0.37.0                |                                                                                        |
-| [Popover](https://opensource.adobe.com/spectrum-web-components/components/popover/)                         | 0.37.0                |                                                                                        |
-| [Quick Actions](https://opensource.adobe.com/spectrum-web-components/components/quick-actions/)             | 0.37.0                |                                                                                        |
-| [Radio](https://opensource.adobe.com/spectrum-web-components/components/radio/)                             | 0.37.0                |                                                                                        |
+| [Picker Button](https://opensource.adobe.com/spectrum-web-components/components/picker-button/)             | 0.37.0                |                                                                                           |
+| [Popover](https://opensource.adobe.com/spectrum-web-components/components/popover/)                         | 0.37.0                |                                                                                           |
+| [Quick Actions](https://opensource.adobe.com/spectrum-web-components/components/quick-actions/)             | 0.37.0                |                                                                                           |
+| [Radio](https://opensource.adobe.com/spectrum-web-components/components/radio/)                             | 0.37.0                |                                                                                           |
 | [Search](https://opensource.adobe.com/spectrum-web-components/components/search/)                           | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/search#known-issues)       |
 | [Sidenav](https://opensource.adobe.com/spectrum-web-components/components/sidenav/)                         | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/sidenav#known-issues)      |
-| [Swatch](https://opensource.adobe.com/spectrum-web-components/components/swatch/)                           | 0.37.0                |                                                                                        |
+| [Swatch](https://opensource.adobe.com/spectrum-web-components/components/swatch/)                           | 0.37.0                |                                                                                           |
 | [Switch](https://opensource.adobe.com/spectrum-web-components/components/switch/)                           | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/switch#known-issues)       |
 | [Table](https://opensource.adobe.com/spectrum-web-components/components/table/)                             | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/table#known-issues)        |
 | [Tags](https://opensource.adobe.com/spectrum-web-components/components/tags/)                               | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/tags#known-issues)         |
 | [Texfield](https://opensource.adobe.com/spectrum-web-components/components/textfield/)                      | 0.37.0                | [Known issues](https://www.npmjs.com/package/@swc-uxp-wrappers/textfield#known-issues)    |
-| [Toast](https://opensource.adobe.com/spectrum-web-components/components/toast/)                             | 0.37.0                |                                                                                        |
-| [Tooltip](https://opensource.adobe.com/spectrum-web-components/components/tooltip/)                         | 0.37.0                |                                                                                        |
-| [Utils](https://www.npmjs.com/package/@swc-uxp-wrappers/utils)                                              | 2.0.1                 |                                                                                        |
+| [Toast](https://opensource.adobe.com/spectrum-web-components/components/toast/)                             | 0.37.0                |                                                                                           |
+| [Tooltip](https://opensource.adobe.com/spectrum-web-components/components/tooltip/)                         | 0.37.0                |                                                                                           |
+| [Utils](https://www.npmjs.com/package/@swc-uxp-wrappers/utils)                                              | 2.0.1                 |                                                                                           |
 
-##### ⚠️ The components which work out of the box  (like Icon , Icons, Icons UI, Icons Workflow, Iconset ) and the ones required for an SWC app (Base , theme , styles,shared,reactive-controllers) are included in the `@swc-uxp-wrappers/utils` package. Therefore these do not need to be loaded explicitly and `uxp-wrappers/utils` becomes a prerequisite for building the `swc-uxp-app`.
+##### ⚠️ The components which work out of the box (like Icon , Icons, Icons UI, Icons Workflow, Iconset ) and the ones required for an SWC app (Base , theme , styles,shared,reactive-controllers) are included in the `@swc-uxp-wrappers/utils` package. Therefore these do not need to be loaded explicitly and `uxp-wrappers/utils` becomes a prerequisite for building the `swc-uxp-app`.
 
 ## Quickstart
 

--- a/packages/accordion/src/uxp-accordion-item.css
+++ b/packages/accordion/src/uxp-accordion-item.css
@@ -72,6 +72,7 @@ governing permissions and limitations under the License.
     );
     width: 100%;
     text-align: left;
+    display: inline-block;
 }
 
 #content {

--- a/packages/split-view/src/uxp-split-view.css
+++ b/packages/split-view/src/uxp-split-view.css
@@ -47,10 +47,8 @@ governing permissions and limitations under the License.
 
 ::slotted(:first-child) {
     min-width: var(--primary-min);
-    overflow: hidden;
 }
 
 ::slotted(:nth-child(2)) {
     min-width: var(--secondary-min);
-    overflow: hidden;
 }

--- a/packages/tabs/src/uxp-tabs.css
+++ b/packages/tabs/src/uxp-tabs.css
@@ -16,6 +16,14 @@ governing permissions and limitations under the License.
     display: block;
 }
 
+::slotted(:not([slot])),
+::slotted(:not([slot])) {
+    color: var(
+        --highcontrast-tabs-color,
+        var(--mod-tabs-color, var(--spectrum-tabs-color))
+    );
+}
+
 :host([direction^='vertical']) {
     display: inline-flex;
 }
@@ -45,6 +53,10 @@ governing permissions and limitations under the License.
 
 :host(:not([disabled])) ::slotted(sp-tab.focus-visible):before {
     border-color: var(--spectrum-focus-indicator-color) !important;
+}
+
+:host([direction='vertical-right']) ::slotted(sp-tab-panel) {
+    margin-left: 2px; /* To compensate for lack of box-sizing support */
 }
 
 :host(:not([disabled])) ::slotted(sp-tab-panel.focus-visible) {

--- a/projects/swc-starter-webpack/src/attach-event-helper.js
+++ b/projects/swc-starter-webpack/src/attach-event-helper.js
@@ -519,6 +519,57 @@ function attachEvents(tabName) {
         `;
         eval(spPickerReadonly);
     }
+
+    if (tabName === 'sp-tabs') {
+        const spTabsSizes = `
+            const sizes = document.getElementById('tabs-sizes');
+            sizes.addEventListener("change", () => {
+                document.querySelector('#dynamic-api-test').setAttribute('size', sizes.value); 
+            });
+        `;
+        eval(spTabsSizes);
+
+        const spTabsDisabled = `
+            document.querySelector('#disabled').addEventListener('change', (evt) => {
+                    const checked = evt.target.checked;
+                    const tabs = document.querySelector('#dynamic-api-test');
+                    if (checked) {
+                        tabs.setAttribute("disabled", "disabled");
+                    } else {
+                        tabs.removeAttribute("disabled");
+                    }
+                });
+        `;
+        eval(spTabsDisabled);
+
+        const spTabsEmphasized = `
+            document.querySelector('#emphasized').addEventListener('change', (evt) => {
+                    const checked = evt.target.checked;
+                    const tabs = document.querySelector('#dynamic-api-test');
+                    if (checked) {
+                        tabs.setAttribute("emphasized", "emphasized");
+                    } else {
+                        tabs.removeAttribute("emphasized");
+                    }
+                });
+        `;
+        eval(spTabsEmphasized);
+
+        const spTabsVertical = `
+            document.querySelector('#vertical').addEventListener('change', (evt) => {
+                const checked = evt.target.checked;
+                const tabs = document.querySelectorAll('[direction^="vertical"]'); // Select all elements with direction="vertical"
+                tabs.forEach(tab => {
+                    if (checked) {
+                        tab.setAttribute("direction", "vertical-right");
+                    } else {
+                        tab.setAttribute("direction", "vertical");
+                    }
+                });
+            });
+        `;
+        eval(spTabsVertical);
+    }
 }
 
 function handleThemeColor(selectObject) {

--- a/projects/swc-starter-webpack/src/example_usages/sp-table.html
+++ b/projects/swc-starter-webpack/src/example_usages/sp-table.html
@@ -25,9 +25,22 @@ governing permissions and limitations under the License.
                     </sp-table-head>
                     <sp-table-body>
                         <sp-table-row>
-                            <sp-table-cell>Row Item Alpha</sp-table-cell>
-                            <sp-table-cell>Row Item Alpha</sp-table-cell>
-                            <sp-table-cell>Row Item Alpha</sp-table-cell>
+                            <sp-table-cell>
+                                <sp-number-field
+                                    value="1024"
+                                    style="--spectrum-stepper-width: 85px"
+                                ></sp-number-field>
+                            </sp-table-cell>
+                            <sp-table-cell>
+                                <sp-textfield
+                                    placeholder="Enter your life story"
+                                ></sp-textfield>
+                            </sp-table-cell>
+                            <sp-table-cell>
+                                <sp-search
+                                    placeholder="Search here"
+                                ></sp-search>
+                            </sp-table-cell>
                         </sp-table-row>
                         <sp-table-row>
                             <sp-table-cell>Row Item Bravo</sp-table-cell>

--- a/projects/swc-starter-webpack/src/example_usages/sp-tabs.html
+++ b/projects/swc-starter-webpack/src/example_usages/sp-tabs.html
@@ -37,7 +37,7 @@ governing permissions and limitations under the License.
             <div class="demo-example">
                 <div class="size-div non-flex">
                     <sp-field-label for="s">Small</sp-field-label>
-                    <sp-tabs selected="2" size="s">
+                    <sp-tabs id="dynamic-api-test" selected="2" size="s">
                         <sp-tab label="Tab 1" value="1"></sp-tab>
                         <sp-tab label="Tab 2" value="2"></sp-tab>
                         <sp-tab label="Tab 3" value="3"></sp-tab>
@@ -263,7 +263,7 @@ governing permissions and limitations under the License.
             <div class="demo-example">
                 <div class="size-div non-flex">
                     <sp-tabs selected="2">
-                        <sp-tab label="Tab 1" value="1"></sp-tab>
+                        <sp-tab label="Tab 1" value="1" disabled></sp-tab>
                         <sp-tab label="Tab 2" value="2"></sp-tab>
                         <sp-tab label="Tab 3" value="3" disabled></sp-tab>
                         <sp-tab label="Tab 4" value="4"></sp-tab>
@@ -1241,6 +1241,59 @@ governing permissions and limitations under the License.
                     </sp-tabs>
                 </div>
             </div>
+
+            <div id="variantLabel">vertical-right</div>
+            <div class="demo-example">
+                <div class="size-div non-flex">
+                    <sp-tabs selected="2" direction="vertical-right">
+                        <sp-tab label="Tab 1" value="1">
+                            <sp-icon-edit slot="icon"></sp-icon-edit>
+                        </sp-tab>
+                        <sp-tab label="Tab 2" value="2">
+                            <sp-icon-more slot="icon"></sp-icon-more>
+                        </sp-tab>
+                        <sp-tab label="Tab 3" value="3">
+                            <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                        </sp-tab>
+                        <sp-tab label="Tab 4" value="4">
+                            <sp-icon-stopwatch slot="icon"></sp-icon-stopwatch>
+                        </sp-tab>
+                        <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+                        <sp-tab-panel value="2">
+                            <div class="container">
+                                <p>
+                                    Lorem ipsum dolor sit amet, consectetuer
+                                    adipiscing elit. Sed ac dolor sit amet purus
+                                    malesuada congue. Donec quis nibh at felis
+                                    congue commodo. Ut enim ad minima veniam,
+                                    quis nostrum exercitationem ullam corporis
+                                    suscipit laboriosam, nisi ut aliquid ex ea
+                                    commodi consequatur
+                                </p>
+                                <sp-field-label
+                                    for="lifestory-1"
+                                    style="width: 100px"
+                                >
+                                    Life Story
+                                </sp-field-label>
+                                <sp-textfield
+                                    placeholder="Enter your life story"
+                                    id="lifestory-1"
+                                ></sp-textfield>
+                                <sp-button
+                                    treatment="outline"
+                                    variant="primary"
+                                    class="align-right"
+                                >
+                                    Submit
+                                </sp-button>
+                            </div>
+                        </sp-tab-panel>
+                        <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+                        <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
+                    </sp-tabs>
+                </div>
+            </div>
         </div>
 
         <input type="text" style="width: 2px" />
@@ -1285,8 +1338,25 @@ governing permissions and limitations under the License.
     </div>
 
     <div id="config">
-        <div style="display: inline-flex"></div>
+        <div style="display: inline-flex">
+            <sp-field-label size="l" side-aligned="end" for="tabs-sizes">
+                Sizes
+            </sp-field-label>
+            <select id="tabs-sizes">
+                <option value="s">Small</option>
+                <option selected value="m" selected>Medium</option>
+                <option value="l">Large</option>
+                <option value="xl">Extra Large</option>
+            </select>
+        </div>
 
-        <div style="display: flex; flex-direction: column"></div>
+        <div style="display: flex; flex-direction: column">
+            <sp-checkbox id="disabled">Disabled</sp-checkbox>
+            <sp-checkbox id="emphasized">Emphasized</sp-checkbox>
+            <div style="display: inline-flex; align-items: center">
+                <div style="padding-right: 10px; font-size: 14px">Vertical</div>
+                <sp-switch id="vertical">Vertical-Right</sp-switch>
+            </div>
+        </div>
     </div>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,7 +1103,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.6.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.8.4":
   version "7.25.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.0.tgz#3af9a91c1b739c569d5d80cc917280919c544ecb"
   integrity sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==
@@ -3022,6 +3022,13 @@
     "@spectrum-web-components/icons-ui" "^0.37.0"
     "@spectrum-web-components/reactive-controllers" "^0.37.0"
     "@spectrum-web-components/shared" "^0.37.0"
+
+"@swc/helpers@^0.5.0":
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.13.tgz#33e63ff3cd0cade557672bd7888a39ce7d115a8c"
+  integrity sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==
+  dependencies:
+    tslib "^2.4.0"
 
 "@tootallnate/once@1":
   version "1.1.2"


### PR DESCRIPTION
Fixes - 

- https://jira.corp.adobe.com/browse/UXP-22886 

>  Description - div-A with display="flex" inside another div-B with display="inline-flex" causes the content inside div-A to gets wrapped and adjusted on some sort of interaction (like mouse hover). This issue arises from how flex and inline-flex layouts interact with their content's available space and resizing. When div-B is set to inline-flex, it behaves like an inline element, meaning its size adjusts based on the content inside. If div-A inside div-B has flex display, it may adjust its width based on how much space is available, potentially causing wrapping or adjusting on hover. Moving to "display=inline-block" on div-A fixes this issue.

- https://jira.corp.adobe.com/browse/UXP-22895
> Adding the style to increase the specificity, solves the issue   
```
::slotted(:not([slot])),
::slotted(:not([slot])) {
    color: var(
        --highcontrast-tabs-color,
        var(--mod-tabs-color, var(--spectrum-tabs-color))
    );
}

```
- https://jira.corp.adobe.com/browse/UXP-22901

> Removed not required style overflow: hidden;

- https://jira.corp.adobe.com/browse/UXP-22885

>  To compensate for lack of box-sizing support, have to add an appropriate polyfil 

`:host([direction='vertical-right']) ::slotted(sp-tab-panel) {
    margin-left: 2px
}`