### PR TITLE
Fix and standardize tab navigation in swc-starter-webpack demo

### DIFF
--- a/projects/swc-starter-webpack/src/index.html
+++ b/projects/swc-starter-webpack/src/index.html
@@ -108,41 +108,10 @@ governing permissions and limitations under the License.
                 </div>
                 <div class="tab">
                     <button
-                        id="trigger-imperative"
                         class="tablinks"
-                        onclick="openTab(event, 'sp-overlay')"
+                        onclick="openTab(event, 'sp-action-bar')"
                     >
-                        sp-overlay
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-banner')"
-                    >
-                        sp-banner
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-illustrated-message')"
-                    >
-                        sp-illustrated-message
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-divider')"
-                    >
-                        sp-divider
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-avatar')"
-                    >
-                        sp-avatar
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-button')"
-                    >
-                        sp-button
+                        sp-action-bar
                     </button>
                     <button
                         class="tablinks"
@@ -158,21 +127,33 @@ governing permissions and limitations under the License.
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-link')"
+                        onclick="openTab(event, 'sp-asset')"
                     >
-                        sp-link
+                        sp-asset
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-field-label')"
+                        onclick="openTab(event, 'sp-avatar')"
                     >
-                        sp-fieldlabel
+                        sp-avatar
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-checkbox')"
+                        onclick="openTab(event, 'sp-banner')"
                     >
-                        sp-checkbox
+                        sp-banner
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-button')"
+                    >
+                        sp-button
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-button-group')"
+                    >
+                        sp-button-group
                     </button>
                     <button
                         class="tablinks"
@@ -182,39 +163,57 @@ governing permissions and limitations under the License.
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-action-bar')"
+                        onclick="openTab(event, 'sp-checkbox')"
                     >
-                        sp-action-bar
+                        sp-checkbox
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-popover')"
+                        onclick="openTab(event, 'sp-dialog')"
                     >
-                        sp-popover
+                        sp-dialog
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-tooltip')"
+                        onclick="openTab(event, 'sp-divider')"
                     >
-                        sp-tooltip
+                        sp-divider
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-picker-button')"
+                        onclick="openTab(event, 'sp-field-group')"
                     >
-                        sp-picker-button
+                        sp-field-group
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-field-label')"
+                    >
+                        sp-field-label
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-help-text')"
+                    >
+                        sp-help-text
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-illustrated-message')"
+                    >
+                        sp-illustrated-message
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-link')"
+                    >
+                        sp-link
                     </button>
                     <button
                         class="tablinks"
                         onclick="openTab(event, 'sp-menu')"
                     >
                         sp-menu
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-menu-item')"
-                    >
-                        sp-menu-item
                     </button>
                     <button
                         class="tablinks"
@@ -230,54 +229,46 @@ governing permissions and limitations under the License.
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-table')"
+                        onclick="openTab(event, 'sp-menu-item')"
                     >
-                        sp-table
+                        sp-menu-item
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-textfield')"
+                        onclick="openTab(event, 'sp-meter')"
                     >
-                        sp-textfield
+                        sp-meter
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-textarea')"
+                        onclick="openTab(event, 'sp-number-field')"
                     >
-                        sp-textfield(multiline)
+                        sp-number-field
+                    </button>
+                    <button
+                        id="trigger-imperative"
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-overlay')"
+                    >
+                        sp-overlay
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-help-text')"
+                        onclick="openTab(event, 'sp-picker-button')"
                     >
-                        sp-help-text
-                    </button>
-                    <button onclick="openTab(event, 'sp-button-group')">
-                        sp-button-group
+                        sp-picker-button
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-dialog')"
+                        onclick="openTab(event, 'sp-popover')"
                     >
-                        sp-dialog
+                        sp-popover
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-toast')"
+                        onclick="openTab(event, 'sp-quick-actions')"
                     >
-                        sp-toast
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-switch')"
-                    >
-                        sp-switch
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-sidenav')"
-                    >
-                        sp-sidenav
+                        sp-quick-actions
                     </button>
                     <button
                         class="tablinks"
@@ -293,51 +284,63 @@ governing permissions and limitations under the License.
                     </button>
                     <button
                         class="tablinks"
-                        onclick="openTab(event, 'sp-tags')"
-                    >
-                        sp-tags
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-field-group')"
-                    >
-                        sp-field-group
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-asset')"
-                    >
-                        sp-asset
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-quick-actions')"
-                    >
-                        sp-quick-actions
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-meter')"
-                    >
-                        sp-meter
-                    </button>
-                    <button
-                        class="tablinks"
-                        onclick="openTab(event, 'sp-number-field')"
-                    >
-                        sp-number-field
-                    </button>
-                    <button
-                        class="tablinks"
                         onclick="openTab(event, 'sp-search')"
                     >
                         sp-search
                     </button>
                     <button
                         class="tablinks"
+                        onclick="openTab(event, 'sp-sidenav')"
+                    >
+                        sp-sidenav
+                    </button>
+                    <button
+                        class="tablinks"
                         onclick="openTab(event, 'sp-swatch')"
                     >
                         sp-swatch
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-switch')"
+                    >
+                        sp-switch
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-table')"
+                    >
+                        sp-table
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-tags')"
+                    >
+                        sp-tags
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-textarea')"
+                    >
+                        sp-textfield(multiline)
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-textfield')"
+                    >
+                        sp-textfield
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-toast')"
+                    >
+                        sp-toast
+                    </button>
+                    <button
+                        class="tablinks"
+                        onclick="openTab(event, 'sp-tooltip')"
+                    >
+                        sp-tooltip
                     </button>
                 </div>
             </div>
@@ -387,24 +390,8 @@ governing permissions and limitations under the License.
                     <span id="logs"></span>
                 </div>
             </div>
-            <div id="sp-banner" class="tabcontent">
-                <!--#include sp-banner.html -->
-            </div>
-
-            <div id="sp-illustrated-message" class="tabcontent">
-                <!--#include sp-illustrated-message.html -->
-            </div>
-
-            <div id="sp-divider" class="tabcontent">
-                <!--#include sp-divider.html -->
-            </div>
-
-            <div id="sp-avatar" class="tabcontent">
-                <!--#include sp-avatar.html -->
-            </div>
-
-            <div id="sp-button" class="tabcontent">
-                <!--#include sp-button.html -->
+            <div id="sp-action-bar" class="tabcontent">
+                <!--#include sp-action-bar.html -->
             </div>
 
             <div id="sp-action-button" class="tabcontent">
@@ -415,36 +402,60 @@ governing permissions and limitations under the License.
                 <!--#include sp-action-group.html -->
             </div>
 
-            <div id="sp-link" class="tabcontent">
-                <!--#include sp-link.html -->
+            <div id="sp-asset" class="tabcontent">
+                <!--#include sp-asset.html -->
             </div>
 
-            <div id="sp-field-label" class="tabcontent">
-                <!--#include sp-field-label.html -->
+            <div id="sp-avatar" class="tabcontent">
+                <!--#include sp-avatar.html -->
             </div>
 
-            <div id="sp-checkbox" class="tabcontent">
-                <!--#include sp-checkbox.html -->
+            <div id="sp-banner" class="tabcontent">
+                <!--#include sp-banner.html -->
+            </div>
+
+            <div id="sp-button" class="tabcontent">
+                <!--#include sp-button.html -->
+            </div>
+
+            <div id="sp-button-group" class="tabcontent">
+                <!--#include sp-button-group.html -->
             </div>
 
             <div id="sp-card" class="tabcontent">
                 <!--#include sp-card.html -->
             </div>
 
-            <div id="sp-action-bar" class="tabcontent">
-                <!--#include sp-action-bar.html -->
+            <div id="sp-checkbox" class="tabcontent">
+                <!--#include sp-checkbox.html -->
             </div>
 
-            <div id="sp-popover" class="tabcontent">
-                <!--#include sp-popover.html -->
+            <div id="sp-dialog" class="tabcontent">
+                <!--#include sp-dialog.html -->
             </div>
 
-            <div id="sp-tooltip" class="tabcontent">
-                <!--#include sp-tooltip.html -->
+            <div id="sp-divider" class="tabcontent">
+                <!--#include sp-divider.html -->
             </div>
 
-            <div id="sp-picker-button" class="tabcontent">
-                <!--#include sp-picker-button.html -->
+            <div id="sp-field-group" class="tabcontent">
+                <!--#include sp-field-group.html -->
+            </div>
+
+            <div id="sp-field-label" class="tabcontent">
+                <!--#include sp-field-label.html -->
+            </div>
+
+            <div id="sp-help-text" class="tabcontent">
+                <!--#include sp-help-text.html -->
+            </div>
+
+            <div id="sp-illustrated-message" class="tabcontent">
+                <!--#include sp-illustrated-message.html -->
+            </div>
+
+            <div id="sp-link" class="tabcontent">
+                <!--#include sp-link.html -->
             </div>
 
             <div id="sp-menu" class="tabcontent">
@@ -455,48 +466,36 @@ governing permissions and limitations under the License.
                 <!--#include sp-menu-divider.html -->
             </div>
 
-            <div id="sp-menu-item" class="tabcontent">
-                <!--#include sp-menu-item.html -->
-            </div>
-
             <div id="sp-menu-group" class="tabcontent">
                 <!--#include sp-menu-group.html -->
             </div>
 
-            <div id="sp-table" class="tabcontent">
-                <!--#include sp-table.html -->
+            <div id="sp-menu-item" class="tabcontent">
+                <!--#include sp-menu-item.html -->
             </div>
 
-            <div id="sp-textfield" class="tabcontent">
-                <!--#include sp-textfield.html -->
+            <div id="sp-meter" class="tabcontent">
+                <!--#include sp-meter.html -->
             </div>
 
-            <div id="sp-help-text" class="tabcontent">
-                <!--#include sp-help-text.html -->
+            <div id="sp-number-field" class="tabcontent">
+                <!--#include sp-number-field.html -->
             </div>
 
-            <div id="sp-button-group" class="tabcontent">
-                <!--#include sp-button-group.html -->
+            <div id="sp-overlay" class="tabcontent">
+                <!--#include sp-overlay.html -->
             </div>
 
-            <div id="sp-dialog" class="tabcontent">
-                <!--#include sp-dialog.html -->
+            <div id="sp-picker-button" class="tabcontent">
+                <!--#include sp-picker-button.html -->
             </div>
 
-            <div id="sp-toast" class="tabcontent">
-                <!--#include sp-toast.html -->
+            <div id="sp-popover" class="tabcontent">
+                <!--#include sp-popover.html -->
             </div>
 
-            <div id="sp-textarea" class="tabcontent">
-                <!--#include sp-textarea.html -->
-            </div>
-
-            <div id="sp-switch" class="tabcontent">
-                <!--#include sp-switch.html -->
-            </div>
-
-            <div id="sp-sidenav" class="tabcontent">
-                <!--#include sp-sidenav.html -->
+            <div id="sp-quick-actions" class="tabcontent">
+                <!--#include sp-quick-actions.html -->
             </div>
 
             <div id="sp-radio" class="tabcontent">
@@ -507,40 +506,44 @@ governing permissions and limitations under the License.
                 <!--#include sp-radio-group.html -->
             </div>
 
-            <div id="sp-tags" class="tabcontent">
-                <!--#include sp-tags.html -->
-            </div>
-
-            <div id="sp-field-group" class="tabcontent">
-                <!--#include sp-field-group.html -->
-            </div>
-
             <div id="sp-search" class="tabcontent">
                 <!--#include sp-search.html -->
             </div>
 
-            <div id="sp-number-field" class="tabcontent">
-                <!--#include sp-number-field.html -->
-            </div>
-
-            <div id="sp-asset" class="tabcontent">
-                <!--#include sp-asset.html -->
-            </div>
-
-            <div id="sp-quick-actions" class="tabcontent">
-                <!--#include sp-quick-actions.html -->
-            </div>
-
-            <div id="sp-meter" class="tabcontent">
-                <!--#include sp-meter.html -->
+            <div id="sp-sidenav" class="tabcontent">
+                <!--#include sp-sidenav.html -->
             </div>
 
             <div id="sp-swatch" class="tabcontent">
                 <!--#include sp-swatch.html -->
             </div>
 
-            <div id="sp-overlay" class="tabcontent">
-                <!--#include sp-overlay.html -->
+            <div id="sp-switch" class="tabcontent">
+                <!--#include sp-switch.html -->
+            </div>
+
+            <div id="sp-table" class="tabcontent">
+                <!--#include sp-table.html -->
+            </div>
+
+            <div id="sp-tags" class="tabcontent">
+                <!--#include sp-tags.html -->
+            </div>
+
+            <div id="sp-textarea" class="tabcontent">
+                <!--#include sp-textarea.html -->
+            </div>
+
+            <div id="sp-textfield" class="tabcontent">
+                <!--#include sp-textfield.html -->
+            </div>
+
+            <div id="sp-toast" class="tabcontent">
+                <!--#include sp-toast.html -->
+            </div>
+
+            <div id="sp-tooltip" class="tabcontent">
+                <!--#include sp-tooltip.html -->
             </div>
         </sp-theme>
     </body>


### PR DESCRIPTION
## Description
- Reorder all 39 tab buttons and tabcontent divs in index.html alphabetically by component name
- Fix button label: "sp-fieldlabel" → "sp-field-label"
- Add missing class="tablinks" to sp-button-group button

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
